### PR TITLE
AB-1474,AB-1475 Add close and reclaim fee credit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "import/extensions": ["error", "ignorePackages"],
     "import/no-unresolved": "off",
     "@typescript-eslint/explicit-member-accessibility": "error",
-    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/naming-convention": [
       "error",
       {
@@ -27,7 +27,18 @@
           "match": true
         }
       }
-    ]
+    ],
+    "import/order": ["error", {"alphabetize": {"order": "asc", "caseInsensitive": true}}]
   },
-  "ignorePatterns": []
+  "overrides": [
+    {
+      "files": ["*.ts", "*.mts", "*.cts", "*.tsx"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "error"
+      }
+    }
+  ],
+  "ignorePatterns": [
+    "lib/**/*"
+  ]
 }

--- a/examples/burnFungibleToken/main.mjs
+++ b/examples/burnFungibleToken/main.mjs
@@ -1,27 +1,27 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
+import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { BurnFungibleTokenAttributes } from '../../lib/transaction/BurnFungibleTokenAttributes.js';
+import { BurnFungibleTokenPayload } from '../../lib/transaction/BurnFungibleTokenPayload.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { SplitFungibleTokenAttributes } from '../../lib/transaction/SplitFungibleTokenAttributes.js';
+import { SplitFungibleTokenPayload } from '../../lib/transaction/SplitFungibleTokenPayload.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
-import { SplitFungibleTokenPayload } from '../../lib/transaction/SplitFungibleTokenPayload.js';
-import { SplitFungibleTokenAttributes } from '../../lib/transaction/SplitFungibleTokenAttributes.js';
-import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
-import { BurnFungibleTokenPayload } from '../../lib/transaction/BurnFungibleTokenPayload.js';
-import { BurnFungibleTokenAttributes } from '../../lib/transaction/BurnFungibleTokenAttributes.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
-import { waitTransactionProof } from "../waitTransactionProof.mjs";
+import { waitTransactionProof } from '../waitTransactionProof.mjs';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -31,19 +31,13 @@ const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), Sy
 const round = await client.getRoundNumber();
 
 // expects that the fungible token has already been created
-const unitId = new UnitIdWithType(
-  new Uint8Array([1, 2, 3, 4, 5]),
-  UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN
-);
-const fungibleTokenType = new UnitIdWithType(
-  new Uint8Array([1, 2, 3]),
-  UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN_TYPE
-);
+const unitId = new UnitIdWithType(new Uint8Array([1, 2, 3, 4, 5]), UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN);
+const fungibleTokenType = new UnitIdWithType(new Uint8Array([1, 2, 3]), UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN_TYPE);
 const token = await client.getUnit(unitId, false);
 
 // 1. split the fungible token
 const targetValue = 1n;
-console.log('Original token\'s value before split: ' + token.data.value);
+console.log("Original token's value before split: " + token.data.value);
 const remainingValue = token.data.value - targetValue;
 const splitTransactionHash = await client.sendTransaction(
   await transactionOrderFactory.createTransaction(
@@ -55,15 +49,17 @@ const splitTransactionHash = await client.sendTransaction(
         token.data.backlink,
         fungibleTokenType,
         remainingValue,
-        [null]
+        [null],
       ),
       token.unitId,
       {
         maxTransactionFee: 5n,
         timeout: round + 60n,
-        feeCreditRecordId: feeCreditUnitId
-      }
-    )));
+        feeCreditRecordId: feeCreditUnitId,
+      },
+    ),
+  ),
+);
 
 // 1b. wait for transaction to finalize
 await waitTransactionProof(client, splitTransactionHash);
@@ -71,13 +67,13 @@ await waitTransactionProof(client, splitTransactionHash);
 // 2. find the token that was split, here as a hack to just take second token from list
 const unitIds = await client.getUnitsByOwnerId(signingService.publicKey);
 const splitTokenId = unitIds.at(1);
-const splitToken = await client.getUnit(splitTokenId)
+const splitToken = await client.getUnit(splitTokenId);
 console.log('Split token ID: ' + Base16Converter.encode(splitTokenId.getBytes()));
 console.log('Split token value: ' + splitToken.data.value);
 
 // 3. check that the original tokens value has been reduced
 const originalTokenAfterSplit = await client.getUnit(unitId, false);
-console.log('Original token\'s value after split: ' + originalTokenAfterSplit.data.value);
+console.log("Original token's value after split: " + originalTokenAfterSplit.data.value);
 
 // 4. burn the split token using original fungible token as target
 const burnTransactionHash = await client.sendTransaction(
@@ -89,13 +85,15 @@ const burnTransactionHash = await client.sendTransaction(
         originalTokenAfterSplit.unitId,
         originalTokenAfterSplit.data.backlink,
         splitToken.data.backlink,
-        [null]
+        [null],
       ),
       splitToken.unitId,
       {
         maxTransactionFee: 5n,
         timeout: round + 60n,
-        feeCreditRecordId: feeCreditUnitId
-      }
-    )));
+        feeCreditRecordId: feeCreditUnitId,
+      },
+    ),
+  ),
+);
 console.log(burnTransactionHash);

--- a/examples/createFungibleToken/main.mjs
+++ b/examples/createFungibleToken/main.mjs
@@ -1,24 +1,24 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
-import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { CreateFungibleTokenAttributes } from '../../lib/transaction/CreateFungibleTokenAttributes.js';
+import { CreateFungibleTokenPayload } from '../../lib/transaction/CreateFungibleTokenPayload.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { CreateFungibleTokenPayload } from '../../lib/transaction/CreateFungibleTokenPayload.js';
-import { CreateFungibleTokenAttributes } from '../../lib/transaction/CreateFungibleTokenAttributes.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -26,12 +26,8 @@ const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingSe
 
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.TOKEN_PARTITION);
 const round = await client.getRoundNumber();
-const unitId = new UnitIdWithType(
-  new Uint8Array([1, 2, 3, 4, 5]),
-  UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN,
-);
-
-const transactionHash = await client.sendTransaction(
+const unitId = new UnitIdWithType(new Uint8Array([1, 2, 3, 4, 5]), UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN);
+await client.sendTransaction(
   await transactionOrderFactory.createTransaction(
     new CreateFungibleTokenPayload(
       unitId,

--- a/examples/createFungibleTokenType/main.mjs
+++ b/examples/createFungibleTokenType/main.mjs
@@ -1,25 +1,25 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
-import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
-import { CreateFungibleTokenTypePayload } from '../../lib/transaction/CreateFungibleTokenTypePayload.js';
-import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
-import { CreateFungibleTokenTypeAttributes } from "../../lib/transaction/CreateFungibleTokenTypeAttributes.js";
-import { TokenIcon } from '../../lib/transaction/TokenIcon.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { AlwaysTruePredicate } from '../../lib/transaction/AlwaysTruePredicate.js';
+import { CreateFungibleTokenTypeAttributes } from '../../lib/transaction/CreateFungibleTokenTypeAttributes.js';
+import { CreateFungibleTokenTypePayload } from '../../lib/transaction/CreateFungibleTokenTypePayload.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { TokenIcon } from '../../lib/transaction/TokenIcon.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
+import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));

--- a/examples/createNonFungibleToken/main.mjs
+++ b/examples/createNonFungibleToken/main.mjs
@@ -1,26 +1,26 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
-import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
-import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { AlwaysTruePredicate } from '../../lib/transaction/AlwaysTruePredicate.js';
-import { UnitType } from '../../lib/transaction/UnitType.js';
-import { CreateNonFungibleTokenPayload } from '../../lib/transaction/CreateNonFungibleTokenPayload.js';
 import { CreateNonFungibleTokenAttributes } from '../../lib/transaction/CreateNonFungibleTokenAttributes.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { CreateNonFungibleTokenPayload } from '../../lib/transaction/CreateNonFungibleTokenPayload.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
 import { NonFungibleTokenData } from '../../lib/transaction/NonFungibleTokenData.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
+import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
+import { UnitType } from '../../lib/transaction/UnitType.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -28,12 +28,8 @@ const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingSe
 
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.TOKEN_PARTITION);
 const round = await client.getRoundNumber();
-const unitId = new UnitIdWithType(
-  new Uint8Array([1, 2, 3, 4, 5]),
-  UnitType.TOKEN_PARTITION_NON_FUNGIBLE_TOKEN,
-);
-
-const transactionHash = await client.sendTransaction(
+const unitId = new UnitIdWithType(new Uint8Array([1, 2, 3, 4, 5]), UnitType.TOKEN_PARTITION_NON_FUNGIBLE_TOKEN);
+await client.sendTransaction(
   await transactionOrderFactory.createTransaction(
     new CreateNonFungibleTokenPayload(
       unitId,

--- a/examples/createNonFungibleTokenType/main.mjs
+++ b/examples/createNonFungibleTokenType/main.mjs
@@ -1,25 +1,25 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
-import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
-import { CreateNonFungibleTokenTypePayload } from '../../lib/transaction/CreateNonFungibleTokenTypePayload.js';
-import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
-import { CreateNonFungibleTokenTypeAttributes } from '../../lib/transaction/CreateNonFungibleTokenTypeAttributes.js';
-import { TokenIcon } from '../../lib/transaction/TokenIcon.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { AlwaysTruePredicate } from '../../lib/transaction/AlwaysTruePredicate.js';
+import { CreateNonFungibleTokenTypeAttributes } from '../../lib/transaction/CreateNonFungibleTokenTypeAttributes.js';
+import { CreateNonFungibleTokenTypePayload } from '../../lib/transaction/CreateNonFungibleTokenTypePayload.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { TokenIcon } from '../../lib/transaction/TokenIcon.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
+import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));

--- a/examples/getBlock/main.mjs
+++ b/examples/getBlock/main.mjs
@@ -1,7 +1,7 @@
-import { createPublicClient } from '../../lib/StateApiClient.js';
-import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
+import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
@@ -10,7 +10,5 @@ const client = createPublicClient({
   transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), new CborCodecNode()),
 });
 
-console.log(
-  Base16Converter.encode(
-    await client.getBlock(
-      await client.getRoundNumber())));
+const round = await client.getRoundNumber();
+console.log(Base16Converter.encode(await client.getBlock(round)));

--- a/examples/getRoundNumber/main.mjs
+++ b/examples/getRoundNumber/main.mjs
@@ -1,7 +1,7 @@
-import { createPublicClient } from '../../lib/StateApiClient.js';
+import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
-import { CborCodecNode }  from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import config from '../config.js';
 
 const client = createPublicClient({

--- a/examples/getUnit/main.mjs
+++ b/examples/getUnit/main.mjs
@@ -1,11 +1,11 @@
-import { createPublicClient } from '../../lib/StateApiClient.js';
-import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
+import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
 
-import config from '../config.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { Base16Converter } from '../../lib/util/Base16Converter.js';
+import config from '../config.js';
 
 const client = createPublicClient({
   transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), new CborCodecNode()),
@@ -16,5 +16,5 @@ const unitIds = await client.getUnitsByOwnerId(signingService.publicKey);
 if (unitIds.length > 0) {
   console.log(await client.getUnit(unitIds.at(-1), true));
 } else {
-  console.log("No units available");
+  console.log('No units available');
 }

--- a/examples/getUnitsByOwnerId/main.mjs
+++ b/examples/getUnitsByOwnerId/main.mjs
@@ -1,9 +1,9 @@
-import { createPublicClient } from '../../lib/StateApiClient.js';
+import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
-import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
-import { CborCodecNode }  from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
+import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
@@ -18,7 +18,7 @@ const moneyClient = createPublicClient({
 
 const moneyUnitIds = await moneyClient.getUnitsByOwnerId(signingService.publicKey);
 if (moneyUnitIds.length > 0) {
-  console.log('Money partition units:')
+  console.log('Money partition units:');
   moneyUnitIds.map((id) => console.log(Base16Converter.encode(id.getBytes())));
 }
 
@@ -29,6 +29,6 @@ const tokenClient = createPublicClient({
 
 const tokenUnitIds = await tokenClient.getUnitsByOwnerId(signingService.publicKey);
 if (tokenUnitIds.length > 0) {
-  console.log('Token partition units:')
+  console.log('Token partition units:');
   tokenUnitIds.map((id) => console.log(Base16Converter.encode(id.getBytes())));
 }

--- a/examples/lockBill/main.mjs
+++ b/examples/lockBill/main.mjs
@@ -1,23 +1,23 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
+import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { LockBillAttributes } from '../../lib/transaction/LockBillAttributes.js';
+import { LockBillPayload } from '../../lib/transaction/LockBillPayload.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
-import { LockBillPayload } from '../../lib/transaction/LockBillPayload.js';
-import { LockBillAttributes } from '../../lib/transaction/LockBillAttributes.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec)
+  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -29,23 +29,13 @@ unitIdBytes.set([0x01], 31);
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.MONEY_PARTITION);
 const round = await client.getRoundNumber();
 
-const bill = await client.getUnit(
-  new UnitIdWithType(unitIdBytes, UnitType.MONEY_PARTITION_BILL_DATA),
-  false,
-);
+const bill = await client.getUnit(new UnitIdWithType(unitIdBytes, UnitType.MONEY_PARTITION_BILL_DATA), false);
 
-const payload = new LockBillPayload(
-  new LockBillAttributes(
-    5n,
-    bill.data.backlink,
-  ),
-  bill.unitId,
-  {
-    maxTransactionFee: 5n,
-    timeout: round + 60n,
-    feeCreditRecordId: feeCreditUnitId,
-  },
-);
+const payload = new LockBillPayload(new LockBillAttributes(5n, bill.data.backlink), bill.unitId, {
+  maxTransactionFee: 5n,
+  timeout: round + 60n,
+  feeCreditRecordId: feeCreditUnitId,
+});
 
 const hash = await client.sendTransaction(await transactionOrderFactory.createTransaction(payload));
 console.log(hash);

--- a/examples/reclaimFeeCredits/main.mjs
+++ b/examples/reclaimFeeCredits/main.mjs
@@ -1,0 +1,78 @@
+import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
+import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
+import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
+import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { CloseFeeCreditAttributes } from '../../lib/transaction/CloseFeeCreditAttributes.js';
+import { CloseFeeCreditPayload } from '../../lib/transaction/CloseFeeCreditPayload.js';
+import { FeeCreditClientMetadata } from '../../lib/transaction/FeeCreditClientMetadata.js';
+import { ReclaimFeeCreditAttributes } from '../../lib/transaction/ReclaimFeeCreditAttributes.js';
+import { ReclaimFeeCreditPayload } from '../../lib/transaction/ReclaimFeeCreditPayload.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
+import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
+import { UnitType } from '../../lib/transaction/UnitType.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
+import config from '../config.js';
+import { waitTransactionProof } from '../waitTransactionProof.mjs';
+
+const cborCodec = new CborCodecNode();
+const tokenClient = createPublicClient({
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
+});
+const moneyClient = createPublicClient({
+  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec),
+});
+const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
+const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingService);
+
+const unitIds = await tokenClient.getUnitsByOwnerId(signingService.publicKey);
+const targetUnitIdHex = '0x000000000000000000000000000000000000000000000000000000000000000100';
+const targetUnitId = new UnitIdWithType(
+  new Uint8Array(Base16Converter.decode(targetUnitIdHex)),
+  UnitType.MONEY_PARTITION_BILL_DATA,
+);
+const feeCreditUnitId = unitIds
+  .filter((id) => {
+    return (
+      Base16Converter.encode(id.getType()) ===
+      Base16Converter.encode(new Uint8Array([UnitType.TOKEN_PARTITION_FEE_CREDIT_RECORD]))
+    );
+  })
+  .at(1);
+
+if (!feeCreditUnitId) {
+  throw new Error('No fee credit available');
+}
+
+const targetBill = await moneyClient.getUnit(targetUnitId, false);
+const feeCredit = await tokenClient.getUnit(feeCreditUnitId, false);
+const round = await tokenClient.getRoundNumber();
+
+console.log(feeCredit);
+
+let transactionHash = await tokenClient.sendTransaction(
+  await transactionOrderFactory.createTransaction(
+    new CloseFeeCreditPayload(
+      new CloseFeeCreditAttributes(feeCredit.data.balance, targetBill.unitId, targetBill.data.backlink),
+      SystemIdentifier.TOKEN_PARTITION,
+      feeCredit.unitId,
+      new FeeCreditClientMetadata(5n, round + 60n),
+    ),
+  ),
+);
+
+const transactionProof = await waitTransactionProof(tokenClient, transactionHash);
+
+transactionHash = await moneyClient.sendTransaction(
+  await transactionOrderFactory.createTransaction(
+    new ReclaimFeeCreditPayload(
+      new ReclaimFeeCreditAttributes(transactionProof, targetBill.data.backlink),
+      targetBill.unitId,
+      new FeeCreditClientMetadata(5n, round + 60n),
+    ),
+  ),
+);
+
+console.log((await waitTransactionProof(moneyClient, transactionHash))?.toString());

--- a/examples/splitBill/main.mjs
+++ b/examples/splitBill/main.mjs
@@ -1,25 +1,25 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
+import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { SplitBillAttributes } from '../../lib/transaction/SplitBillAttributes.js';
+import { SplitBillPayload } from '../../lib/transaction/SplitBillPayload.js';
+import { SplitBillUnit } from '../../lib/transaction/SplitBillUnit.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
-import { SplitBillPayload } from '../../lib/transaction/SplitBillPayload.js';
-import { SplitBillAttributes } from '../../lib/transaction/SplitBillAttributes.js';
-import { SplitBillUnit } from '../../lib/transaction/SplitBillUnit.js';
-import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec)
+  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -31,16 +31,13 @@ unitIdBytes.set([0x01], 31);
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.MONEY_PARTITION);
 const round = await client.getRoundNumber();
 
-const bill = await client.getUnit(
-  new UnitIdWithType(unitIdBytes, UnitType.MONEY_PARTITION_BILL_DATA),
-  false,
-);
+const bill = await client.getUnit(new UnitIdWithType(unitIdBytes, UnitType.MONEY_PARTITION_BILL_DATA), false);
 
 const payload = new SplitBillPayload(
   new SplitBillAttributes(
     [
       new SplitBillUnit(10000n, await PayToPublicKeyHashPredicate.Create(cborCodec, signingService.publicKey)),
-      new SplitBillUnit(10000n, await PayToPublicKeyHashPredicate.Create(cborCodec, signingService.publicKey))
+      new SplitBillUnit(10000n, await PayToPublicKeyHashPredicate.Create(cborCodec, signingService.publicKey)),
     ],
     bill.data.value - 20000n,
     bill.data.backlink,

--- a/examples/splitFungibleToken/main.mjs
+++ b/examples/splitFungibleToken/main.mjs
@@ -1,24 +1,24 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
+import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { SplitFungibleTokenAttributes } from '../../lib/transaction/SplitFungibleTokenAttributes.js';
+import { SplitFungibleTokenPayload } from '../../lib/transaction/SplitFungibleTokenPayload.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
-import { SplitFungibleTokenPayload } from '../../lib/transaction/SplitFungibleTokenPayload.js';
-import { SplitFungibleTokenAttributes } from '../../lib/transaction/SplitFungibleTokenAttributes.js';
-import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -28,14 +28,8 @@ const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), Sy
 const round = await client.getRoundNumber();
 
 // expects that the fungible token has already been created
-const unitId = new UnitIdWithType(
-  new Uint8Array([1, 2, 3, 4, 5]),
-  UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN
-);
-const fungibleTokenType = new UnitIdWithType(
-  new Uint8Array([1, 2, 3]),
-  UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN_TYPE
-);
+const unitId = new UnitIdWithType(new Uint8Array([1, 2, 3, 4, 5]), UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN);
+const fungibleTokenType = new UnitIdWithType(new Uint8Array([1, 2, 3]), UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN_TYPE);
 const token = await client.getUnit(unitId, false);
 console.log(token);
 
@@ -51,13 +45,15 @@ const transactionHash = await client.sendTransaction(
         token.data.backlink,
         fungibleTokenType,
         remainingValue,
-        [null]
+        [null],
       ),
       token.unitId,
       {
         maxTransactionFee: 5n,
         timeout: round + 60n,
-        feeCreditRecordId: feeCreditUnitId
-      }
-    )));
+        feeCreditRecordId: feeCreditUnitId,
+      },
+    ),
+  ),
+);
 console.log(transactionHash);

--- a/examples/swapBill/main.mjs
+++ b/examples/swapBill/main.mjs
@@ -1,27 +1,27 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
-import { createPublicClient } from '../../lib/StateApiClient.js';
-import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
 import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
+import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { UnitType } from '../../lib/transaction/UnitType.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { SwapBillsWithDustCollectorAttributes } from '../../lib/transaction/SwapBillsWithDustCollectorAttributes.js';
+import { SwapBillsWithDustCollectorPayload } from '../../lib/transaction/SwapBillsWithDustCollectorPayload.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { TransferBillToDustCollectorPayload } from '../../lib/transaction/TransferBillDustCollectorPayload.js';
 import { TransferBillToDustCollectorAttributes } from '../../lib/transaction/TransferBillToDustCollectorAttributes.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
-import { SwapBillsWithDustCollectorPayload } from '../../lib/transaction/SwapBillsWithDustCollectorPayload.js';
-import { SwapBillsWithDustCollectorAttributes } from '../../lib/transaction/SwapBillsWithDustCollectorAttributes.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
-import { waitTransactionProof } from '../waitTransactionProof.mjs';
+import { UnitType } from '../../lib/transaction/UnitType.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
+import { waitTransactionProof } from '../waitTransactionProof.mjs';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec)
+  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec),
 });
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
 const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingService);
@@ -30,12 +30,17 @@ const unitIds = await client.getUnitsByOwnerId(signingService.publicKey);
 const targetUnitIdHex = '0x000000000000000000000000000000000000000000000000000000000000000100';
 const targetUnitId = new UnitIdWithType(
   new Uint8Array(Base16Converter.decode(targetUnitIdHex)),
-  UnitType.MONEY_PARTITION_BILL_DATA
+  UnitType.MONEY_PARTITION_BILL_DATA,
 );
-const moneyUnitId = unitIds.filter((id) => {
-  return Base16Converter.encode(id.getType()) === Base16Converter.encode(new Uint8Array([UnitType.MONEY_PARTITION_BILL_DATA]))
-    && Base16Converter.encode(id.getBytes()) !== targetUnitIdHex;
-}).at(0);
+const moneyUnitId = unitIds
+  .filter((id) => {
+    return (
+      Base16Converter.encode(id.getType()) ===
+        Base16Converter.encode(new Uint8Array([UnitType.MONEY_PARTITION_BILL_DATA])) &&
+      Base16Converter.encode(id.getBytes()) !== targetUnitIdHex
+    );
+  })
+  .at(0);
 
 if (!moneyUnitId) {
   throw new Error('No bills available');
@@ -46,24 +51,24 @@ const bill = await client.getUnit(moneyUnitId, false);
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.MONEY_PARTITION);
 const round = await client.getRoundNumber();
 
-const transactionHash =
-  await client.sendTransaction(
-    await transactionOrderFactory.createTransaction(
-      new TransferBillToDustCollectorPayload(
-        new TransferBillToDustCollectorAttributes(
-          bill.data.value,
-          targetBill.unitId,
-          targetBill.data.backlink,
-          bill.data.backlink
-        ),
-        bill.unitId,
-        {
-          maxTransactionFee: 5n,
-          timeout: round + 60n,
-          feeCreditRecordId: feeCreditUnitId
-        }
-      )
-    ));
+const transactionHash = await client.sendTransaction(
+  await transactionOrderFactory.createTransaction(
+    new TransferBillToDustCollectorPayload(
+      new TransferBillToDustCollectorAttributes(
+        bill.data.value,
+        targetBill.unitId,
+        targetBill.data.backlink,
+        bill.data.backlink,
+      ),
+      bill.unitId,
+      {
+        maxTransactionFee: 5n,
+        timeout: round + 60n,
+        feeCreditRecordId: feeCreditUnitId,
+      },
+    ),
+  ),
+);
 
 const transactionProof = await waitTransactionProof(client, transactionHash);
 
@@ -79,7 +84,8 @@ await client.sendTransaction(
       {
         maxTransactionFee: 5n,
         timeout: round + 100n,
-        feeCreditRecordId: feeCreditUnitId
-      }
-    )
-  ));
+        feeCreditRecordId: feeCreditUnitId,
+      },
+    ),
+  ),
+);

--- a/examples/transferBill/main.mjs
+++ b/examples/transferBill/main.mjs
@@ -1,32 +1,37 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
-import { createPublicClient } from '../../lib/StateApiClient.js';
-import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
 import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
+import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { UnitType } from '../../lib/transaction/UnitType.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
 import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
-import { TransferBillPayload } from '../../lib/transaction/TransferBillPayload.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { TransferBillAttributes } from '../../lib/transaction/TransferBillAttributes.js';
+import { TransferBillPayload } from '../../lib/transaction/TransferBillPayload.js';
+import { UnitType } from '../../lib/transaction/UnitType.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec)
+  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec),
 });
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
 const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingService);
 
 const unitIds = await client.getUnitsByOwnerId(signingService.publicKey);
-const moneyUnitId = unitIds.filter((id) => {
-  return Base16Converter.encode(id.getType()) === Base16Converter.encode(new Uint8Array([UnitType.MONEY_PARTITION_BILL_DATA]))
-    && Base16Converter.encode(id.getBytes()) !== '0x000000000000000000000000000000000000000000000000000000000000000100';
-}).at(0);
+const moneyUnitId = unitIds
+  .filter((id) => {
+    return (
+      Base16Converter.encode(id.getType()) ===
+        Base16Converter.encode(new Uint8Array([UnitType.MONEY_PARTITION_BILL_DATA])) &&
+      Base16Converter.encode(id.getBytes()) !== '0x000000000000000000000000000000000000000000000000000000000000000100'
+    );
+  })
+  .at(0);
 
 if (!moneyUnitId) {
   throw new Error('No bills available');
@@ -36,22 +41,22 @@ const bill = await client.getUnit(moneyUnitId, false);
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.MONEY_PARTITION);
 const round = await client.getRoundNumber();
 
-const transactionHash =
-  await client.sendTransaction(
-    await transactionOrderFactory.createTransaction(
-      new TransferBillPayload(
-        new TransferBillAttributes(
-          await PayToPublicKeyHashPredicate.Create(cborCodec, signingService.publicKey),
-          bill.data.value,
-          bill.data.backlink
-        ),
-        bill.unitId,
-        {
-          maxTransactionFee: 5n,
-          timeout: round + 60n,
-          feeCreditRecordId: feeCreditUnitId
-        }
-      )
-    ));
+const transactionHash = await client.sendTransaction(
+  await transactionOrderFactory.createTransaction(
+    new TransferBillPayload(
+      new TransferBillAttributes(
+        await PayToPublicKeyHashPredicate.Create(cborCodec, signingService.publicKey),
+        bill.data.value,
+        bill.data.backlink,
+      ),
+      bill.unitId,
+      {
+        maxTransactionFee: 5n,
+        timeout: round + 60n,
+        feeCreditRecordId: feeCreditUnitId,
+      },
+    ),
+  ),
+);
 
 console.log(transactionHash);

--- a/examples/transferFungibleToken/main.mjs
+++ b/examples/transferFungibleToken/main.mjs
@@ -1,24 +1,24 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
-import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
+import { TransferFungibleTokenAttributes } from '../../lib/transaction/TransferFungibleTokenAttributes.js';
+import { TransferFungibleTokenPayload } from '../../lib/transaction/TransferFungibleTokenPayload.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
-import { TransferFungibleTokenPayload } from '../../lib/transaction/TransferFungibleTokenPayload.js';
-import { TransferFungibleTokenAttributes } from '../../lib/transaction/TransferFungibleTokenAttributes.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -26,10 +26,7 @@ const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingSe
 
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.TOKEN_PARTITION);
 const round = await client.getRoundNumber();
-const unitId = new UnitIdWithType(
-  new Uint8Array([1, 2, 3, 4, 5]),
-  UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN,
-);
+const unitId = new UnitIdWithType(new Uint8Array([1, 2, 3, 4, 5]), UnitType.TOKEN_PARTITION_FUNGIBLE_TOKEN);
 
 const token = await client.getUnit(unitId, false);
 if (token === null) {

--- a/examples/transferNonFungibleToken/main.mjs
+++ b/examples/transferNonFungibleToken/main.mjs
@@ -1,24 +1,24 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
-import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
+import { TransferNonFungibleTokenAttributes } from '../../lib/transaction/TransferNonFungibleTokenAttributes.js';
+import { TransferNonFungibleTokenPayload } from '../../lib/transaction/TransferNonFungibleTokenPayload.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { PayToPublicKeyHashPredicate } from '../../lib/transaction/PayToPublicKeyHashPredicate.js';
-import { TransferNonFungibleTokenPayload } from '../../lib/transaction/TransferNonFungibleTokenPayload.js';
-import { TransferNonFungibleTokenAttributes } from '../../lib/transaction/TransferNonFungibleTokenAttributes.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -26,10 +26,7 @@ const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingSe
 
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.TOKEN_PARTITION);
 const round = await client.getRoundNumber();
-const unitId = new UnitIdWithType(
-  new Uint8Array([1, 2, 3, 4, 5]),
-  UnitType.TOKEN_PARTITION_NON_FUNGIBLE_TOKEN,
-);
+const unitId = new UnitIdWithType(new Uint8Array([1, 2, 3, 4, 5]), UnitType.TOKEN_PARTITION_NON_FUNGIBLE_TOKEN);
 
 const token = await client.getUnit(unitId, false);
 if (token === null) {

--- a/examples/unlockBill/main.mjs
+++ b/examples/unlockBill/main.mjs
@@ -1,23 +1,23 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
+import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
 import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
 import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { MoneyPartitionUnitFactory } from '../../lib/json-rpc/MoneyPartitionUnitFactory.js';
-import { UnlockBillPayload } from '../../lib/transaction/UnlockBillPayload.js';
 import { UnlockBillAttributes } from '../../lib/transaction/UnlockBillAttributes.js';
+import { UnlockBillPayload } from '../../lib/transaction/UnlockBillPayload.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec)
+  transport: http(config.moneyPartitionUrl, new MoneyPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -29,22 +29,13 @@ unitIdBytes.set([0x01], 31);
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.MONEY_PARTITION);
 const round = await client.getRoundNumber();
 
-const bill = await client.getUnit(
-  new UnitIdWithType(unitIdBytes, UnitType.MONEY_PARTITION_BILL_DATA),
-  false,
-);
+const bill = await client.getUnit(new UnitIdWithType(unitIdBytes, UnitType.MONEY_PARTITION_BILL_DATA), false);
 
-const payload = new UnlockBillPayload(
-  new UnlockBillAttributes(
-    bill.data.backlink,
-  ),
-  bill.unitId,
-  {
-    maxTransactionFee: 5n,
-    timeout: round + 60n,
-    feeCreditRecordId: feeCreditUnitId,
-  },
-);
+const payload = new UnlockBillPayload(new UnlockBillAttributes(bill.data.backlink), bill.unitId, {
+  maxTransactionFee: 5n,
+  timeout: round + 60n,
+  feeCreditRecordId: feeCreditUnitId,
+});
 
 const hash = await client.sendTransaction(await transactionOrderFactory.createTransaction(payload));
 console.log(hash);

--- a/examples/updateNonFungibleToken/main.mjs
+++ b/examples/updateNonFungibleToken/main.mjs
@@ -1,24 +1,24 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { createPublicClient } from '../../lib/StateApiClient.js';
 import { CborCodecNode } from '../../lib/codec/cbor/CborCodecNode.js';
 import { http } from '../../lib/json-rpc/StateApiJsonRpcService.js';
-import { Base16Converter } from '../../lib/util/Base16Converter.js';
-import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
-import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
-import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
-import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
 import { TokenPartitionUnitFactory } from '../../lib/json-rpc/TokenPartitionUnitFactory.js';
+import { DefaultSigningService } from '../../lib/signing/DefaultSigningService.js';
+import { createPublicClient } from '../../lib/StateApiClient.js';
+import { SystemIdentifier } from '../../lib/SystemIdentifier.js';
+import { FeeCreditUnitId } from '../../lib/transaction/FeeCreditUnitId.js';
+import { NonFungibleTokenData } from '../../lib/transaction/NonFungibleTokenData.js';
+import { TransactionOrderFactory } from '../../lib/transaction/TransactionOrderFactory.js';
 import { UnitIdWithType } from '../../lib/transaction/UnitIdWithType.js';
 import { UnitType } from '../../lib/transaction/UnitType.js';
-import { NonFungibleTokenData } from '../../lib/transaction/NonFungibleTokenData.js';
-import { UpdateNonFungibleTokenPayload } from '../../lib/transaction/UpdateNonFungibleTokenPayload.js';
 import { UpdateNonFungibleTokenAttributes } from '../../lib/transaction/UpdateNonFungibleTokenAttributes.js';
+import { UpdateNonFungibleTokenPayload } from '../../lib/transaction/UpdateNonFungibleTokenPayload.js';
+import { Base16Converter } from '../../lib/util/Base16Converter.js';
 
 import config from '../config.js';
 
 const cborCodec = new CborCodecNode();
 const client = createPublicClient({
-  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec)
+  transport: http(config.tokenPartitionUrl, new TokenPartitionUnitFactory(), cborCodec),
 });
 
 const signingService = new DefaultSigningService(Base16Converter.decode(config.privateKey));
@@ -26,28 +26,23 @@ const transactionOrderFactory = new TransactionOrderFactory(cborCodec, signingSe
 
 const feeCreditUnitId = new FeeCreditUnitId(sha256(signingService.publicKey), SystemIdentifier.TOKEN_PARTITION);
 const round = await client.getRoundNumber();
-const unitId = new UnitIdWithType(
-  new Uint8Array([1, 2, 3, 4, 5]),
-  UnitType.TOKEN_PARTITION_NON_FUNGIBLE_TOKEN,
-);
+const unitId = new UnitIdWithType(new Uint8Array([1, 2, 3, 4, 5]), UnitType.TOKEN_PARTITION_NON_FUNGIBLE_TOKEN);
 
 const unit = await client.getUnit(unitId, false);
 const data = [crypto.getRandomValues(new Uint8Array(32))];
-
-const transactionHash = await client.sendTransaction(
+await client.sendTransaction(
   await transactionOrderFactory.createTransaction(
     new UpdateNonFungibleTokenPayload(
       unitId,
-      new UpdateNonFungibleTokenAttributes(
-        await NonFungibleTokenData.Create(cborCodec, data),
-        unit?.data.backlink,
-        [null, null]
-      ),
+      new UpdateNonFungibleTokenAttributes(await NonFungibleTokenData.Create(cborCodec, data), unit?.data.backlink, [
+        null,
+        null,
+      ]),
       {
         maxTransactionFee: 5n,
         timeout: round + 60n,
         feeCreditRecordId: feeCreditUnitId,
       },
-    )
+    ),
   ),
 );

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,11 +5,9 @@ export default {
     '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
   moduleNameMapper: {
-    "^(\\.\\.?/.*)\\.js$": "$1"
+    '^(\\.\\.?/.*)\\.js$': '$1',
   },
   testMatch: ['<rootDir>/tests/**/*.ts'],
   collectCoverage: true,
-  collectCoverageFrom: [
-    '<rootDir>/src/**/*.ts'
-  ],
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/uuid": "^9.0.8",
-        "@typescript-eslint/eslint-plugin": "^7.3.1",
-        "@typescript-eslint/parser": "^7.3.1",
+        "@typescript-eslint/eslint-plugin": "^7.4.0",
+        "@typescript-eslint/parser": "^7.4.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
@@ -28,7 +28,7 @@
         "jest-junit": "^16.0.0",
         "prettier": "^3.2.5",
         "ts-jest": "^29.1.2",
-        "typescript": "^5.4.2"
+        "typescript": "^5.4.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1392,16 +1392,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.3.1.tgz",
-      "integrity": "sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
+      "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/type-utils": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/type-utils": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1460,15 +1460,15 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
-      "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
+      "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1488,13 +1488,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
-      "integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
+      "integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1"
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1505,13 +1505,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.3.1.tgz",
-      "integrity": "sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
+      "integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
-      "integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1545,13 +1545,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
-      "integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
+      "integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1630,17 +1630,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
+      "integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1688,12 +1688,12 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
-      "integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
+      "integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
+        "@typescript-eslint/types": "7.4.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -6252,9 +6252,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "tsc -d",
     "test": "jest",
     "test:ci": "jest tests/ --ci --reporters=default --reporters=jest-junit",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix"
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"examples/**/*.mjs\"",
+    "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"examples/**/*.mjs\" --fix"
   },
   "dependencies": {
     "cbor": "9.0.2",
@@ -24,15 +24,15 @@
     "@types/jest": "^29.5.12",
     "@types/uuid": "^9.0.8",
     "jest": "^29.7.0",
-    "typescript": "^5.4.2",
+    "typescript": "^5.4.3",
     "ts-jest": "^29.1.2",
     "jest-junit": "^16.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.2.5",
-    "@typescript-eslint/parser": "^7.3.1",
-    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.4.0",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
     "eslint-plugin-import": "^2.29.1"
   },
   "jest-junit": {

--- a/src/Bill.ts
+++ b/src/Bill.ts
@@ -1,5 +1,6 @@
-import { Base16Converter } from './util/Base16Converter.js';
 import { IBillDataDto } from './json-rpc/IBillDataDto.js';
+import { Base16Converter } from './util/Base16Converter.js';
+import { dedent } from './util/StringUtils.js';
 
 export class Bill {
   public constructor(
@@ -16,5 +17,14 @@ export class Bill {
       Base16Converter.decode(data.backlink),
       Boolean(Number(data.locked)),
     );
+  }
+
+  public toString(): string {
+    return dedent`
+      Bill
+        Value: ${this.value}
+        Last Update: ${this.lastUpdate}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Locked: ${this.locked}`;
   }
 }

--- a/src/FeeCreditRecord.ts
+++ b/src/FeeCreditRecord.ts
@@ -1,5 +1,7 @@
-import { Base64Converter } from './util/Base64Converter.js';
 import { IFeeCreditRecordDto } from './json-rpc/IFeeCreditRecordDto.js';
+import { Base16Converter } from './util/Base16Converter.js';
+import { Base64Converter } from './util/Base64Converter.js';
+import { dedent } from './util/StringUtils.js';
 
 export class FeeCreditRecord {
   public constructor(
@@ -16,5 +18,14 @@ export class FeeCreditRecord {
       BigInt(data.Timeout),
       Boolean(Number(data.Locked)),
     );
+  }
+
+  public toString(): string {
+    return dedent`
+      FeeCreditRecord
+        Balance: ${this.balance}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Timeout: ${this.timeout}
+        Locked: ${this.locked}`;
   }
 }

--- a/src/FungibleToken.ts
+++ b/src/FungibleToken.ts
@@ -1,8 +1,9 @@
+import { IUnitId } from './IUnitId.js';
+import { IFungibleTokenDto } from './json-rpc/IFungibleTokenDto.js';
+import { UnitFactory } from './json-rpc/UnitFactory.js';
 import { Base16Converter } from './util/Base16Converter.js';
 import { Base64Converter } from './util/Base64Converter.js';
-import { IFungibleTokenDto } from './json-rpc/IFungibleTokenDto.js';
-import { IUnitId } from './IUnitId.js';
-import { UnitFactory } from './json-rpc/UnitFactory.js';
+import { dedent } from './util/StringUtils.js';
 
 export class FungibleToken {
   public constructor(
@@ -21,5 +22,15 @@ export class FungibleToken {
       Base64Converter.decode(data.Backlink),
       Boolean(Number(data.Locked)),
     );
+  }
+
+  public toString(): string {
+    return dedent`
+      FungibleToken
+        Token Type: ${this.tokenType.toString()}
+        Value: ${this.value}
+        Block Number: ${this.blockNumber}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Locked: ${this.locked}`;
   }
 }

--- a/src/IStateApiService.ts
+++ b/src/IStateApiService.ts
@@ -1,12 +1,16 @@
 import { IUnit } from './IUnit.js';
-import { TransactionProof } from './TransactionProof.js';
 import { IUnitId } from './IUnitId.js';
+import { ITransactionPayloadAttributes } from './transaction/ITransactionPayloadAttributes.js';
+import { TransactionPayload } from './transaction/TransactionPayload.js';
+import { TransactionRecordWithProof } from './TransactionRecordWithProof.js';
 
 export interface IStateApiService {
   getRoundNumber(): Promise<bigint>;
   getUnitsByOwnerId(ownerId: Uint8Array): Promise<IUnitId[]>;
   getUnit(unitId: IUnitId, includeStateProof: boolean): Promise<IUnit<unknown> | null>;
   getBlock(blockNumber: bigint): Promise<Uint8Array>;
-  getTransactionProof(transactionHash: Uint8Array): Promise<TransactionProof | null>;
+  getTransactionProof(
+    transactionHash: Uint8Array,
+  ): Promise<TransactionRecordWithProof<TransactionPayload<ITransactionPayloadAttributes>> | null>;
   sendTransaction(transactionBytes: Uint8Array): Promise<Uint8Array>;
 }

--- a/src/IUnit.ts
+++ b/src/IUnit.ts
@@ -4,51 +4,36 @@ export interface IUnit<T> {
   readonly unitId: IUnitId;
   readonly data: T;
   readonly ownerPredicate: Uint8Array;
-  readonly stateProof: {
+  readonly stateProof: IStateProof | null;
+}
+
+export interface IStateProof {
+  readonly unitId: IUnitId;
+  readonly unitValue: bigint;
+  readonly unitLedgerHash: Uint8Array;
+  readonly unitTreeCert: IUnitTreeCert;
+  readonly stateTreeCert: IStateTreeCert;
+  readonly unicityCertificate: unknown;
+}
+
+export interface IUnitTreeCert {
+  readonly transactionRecordHash: Uint8Array;
+  readonly unitDataHash: Uint8Array;
+  readonly path: IPathItem[] | null;
+}
+
+export interface IStateTreeCert {
+  readonly leftSummaryHash: Uint8Array;
+  readonly leftSummaryValue: bigint;
+  readonly rightSummaryHash: Uint8Array;
+  readonly rightSummaryValue: bigint;
+  readonly path: {
     readonly unitId: IUnitId;
-    readonly unitValue: bigint;
-    readonly unitLedgerHash: Uint8Array;
-    readonly unitTreeCert: {
-      readonly transactionRecordHash: Uint8Array;
-      readonly unitDataHash: Uint8Array;
-      readonly path: IPathItem[];
-    };
-    readonly stateTreeCert: {
-      readonly leftSummaryHash: Uint8Array;
-      readonly LeftSummaryValue: bigint;
-      readonly rightSummaryHash: Uint8Array;
-      readonly rightSummaryValue: bigint;
-      readonly path: {
-        readonly unitId: Uint8Array;
-        readonly logsHash: Uint8Array;
-        readonly value: bigint;
-        readonly siblingSummaryHash: Uint8Array;
-        readonly siblingSummaryValue: bigint;
-      };
-    };
-    readonly unicityCertificate: {
-      readonly inputRecord: {
-        readonly previousHash: Uint8Array;
-        readonly hash: Uint8Array;
-        readonly blockHash: Uint8Array;
-        readonly summaryValue: Uint8Array;
-        readonly roundNumber: bigint;
-        readonly sumOfEarnedFees: bigint;
-      };
-      readonly unicityTreeCertificate: {
-        readonly systemIdentifier: bigint;
-        readonly siblingHashes: IPathItem[];
-        readonly systemDescriptionHash: Uint8Array;
-      };
-      readonly unicitySeal: {
-        readonly rootChainRoundNumber: bigint;
-        readonly timestamp: bigint;
-        readonly previousHash: Uint8Array;
-        readonly hash: Uint8Array;
-        readonly signatures: Map<string, Uint8Array>;
-      };
-    };
-  };
+    readonly logsHash: Uint8Array;
+    readonly value: bigint;
+    readonly siblingSummaryHash: Uint8Array;
+    readonly siblingSummaryValue: bigint;
+  }[];
 }
 
 interface IPathItem {

--- a/src/NonFungibleToken.ts
+++ b/src/NonFungibleToken.ts
@@ -1,8 +1,11 @@
+import { IUnitId } from './IUnitId.js';
+import { INonFungibleTokenDto } from './json-rpc/INonFungibleTokenDto.js';
+import { UnitFactory } from './json-rpc/UnitFactory.js';
+import { PredicateBytes } from './PredicateBytes.js';
+import { IPredicate } from './transaction/IPredicate.js';
 import { Base16Converter } from './util/Base16Converter.js';
 import { Base64Converter } from './util/Base64Converter.js';
-import { INonFungibleTokenDto } from './json-rpc/INonFungibleTokenDto.js';
-import { IUnitId } from './IUnitId.js';
-import { UnitFactory } from './json-rpc/UnitFactory.js';
+import { dedent } from './util/StringUtils.js';
 
 export class NonFungibleToken {
   public constructor(
@@ -10,7 +13,7 @@ export class NonFungibleToken {
     public readonly name: string,
     public readonly uri: string,
     public readonly data: Uint8Array,
-    public readonly dataUpdatePredicate: Uint8Array,
+    public readonly dataUpdatePredicate: IPredicate,
     public readonly blockNumber: bigint,
     public readonly backlink: Uint8Array,
     public readonly locked: boolean,
@@ -22,10 +25,23 @@ export class NonFungibleToken {
       data.Name,
       data.URI,
       Base64Converter.decode(data.Data),
-      Base64Converter.decode(data.DataUpdatePredicate),
+      new PredicateBytes(Base64Converter.decode(data.DataUpdatePredicate)),
       BigInt(data.T),
       Base64Converter.decode(data.Backlink),
       Boolean(Number(data.Locked)),
     );
+  }
+
+  public toString(): string {
+    return dedent`
+      NonFungibleToken
+        Token Type: ${this.tokenType.toString()}
+        Name: ${this.name}
+        URI: ${this.uri}
+        Data: ${Base16Converter.encode(this.data)}
+        Data Update Predicate: ${this.dataUpdatePredicate.toString()}
+        Block Number: ${this.blockNumber}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Locked: ${this.locked}`;
   }
 }

--- a/src/PredicateBytes.ts
+++ b/src/PredicateBytes.ts
@@ -1,0 +1,13 @@
+import { Base16Converter } from './util/Base16Converter.js';
+
+export class PredicateBytes {
+  public constructor(private readonly bytes: Uint8Array) {}
+
+  public getBytes(): Uint8Array {
+    return new Uint8Array(this.bytes);
+  }
+
+  public toString(): string {
+    return `PredicateBytes[${Base16Converter.encode(this.bytes)}]`;
+  }
+}

--- a/src/ServerMetadata.ts
+++ b/src/ServerMetadata.ts
@@ -1,0 +1,32 @@
+import { Base16Converter } from './util/Base16Converter.js';
+import { dedent } from './util/StringUtils.js';
+
+export type ServerMetadataArray = readonly [bigint, Uint8Array[], bigint, Uint8Array | null];
+export class ServerMetadata {
+  public constructor(
+    public readonly actualFee: bigint,
+    public readonly targetUnits: Uint8Array[],
+    public readonly successIndicator: bigint,
+    public readonly processingDetails: Uint8Array | null,
+  ) {}
+
+  public toArray(): ServerMetadataArray {
+    return [
+      this.actualFee,
+      this.targetUnits.map((unit) => new Uint8Array(unit)),
+      this.successIndicator,
+      this.processingDetails,
+    ];
+  }
+
+  public toString(): string {
+    return dedent`
+      ServerMetadata
+        Actual Fee: ${this.actualFee}
+        Target Units: [
+          ${this.targetUnits.map((unit) => Base16Converter.encode(unit)).join(',\n')}
+        ]
+        Success indicator: ${this.successIndicator}
+        Processing details: ${this.processingDetails ? Base16Converter.encode(this.processingDetails) : null}`;
+  }
+}

--- a/src/StateApiClient.ts
+++ b/src/StateApiClient.ts
@@ -1,11 +1,11 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { IStateApiService } from './IStateApiService.js';
 import { IUnit } from './IUnit.js';
+import { IUnitId } from './IUnitId.js';
+import { ITransactionPayloadAttributes } from './transaction/ITransactionPayloadAttributes.js';
 import { TransactionOrder } from './transaction/TransactionOrder.js';
 import { TransactionPayload } from './transaction/TransactionPayload.js';
-import { ITransactionPayloadAttributes } from './transaction/ITransactionPayloadAttributes.js';
-import { TransactionProof } from './TransactionProof.js';
-import { IUnitId } from './IUnitId.js';
+import { TransactionRecordWithProof } from './TransactionRecordWithProof.js';
 
 export class StateApiClient {
   private readonly service: IStateApiService;
@@ -30,7 +30,9 @@ export class StateApiClient {
     return this.service.getBlock(blockNumber);
   }
 
-  public async getTransactionProof(transactionHash: Uint8Array): Promise<TransactionProof | null> {
+  public async getTransactionProof(
+    transactionHash: Uint8Array,
+  ): Promise<TransactionRecordWithProof<TransactionPayload<ITransactionPayloadAttributes>> | null> {
     return this.service.getTransactionProof(transactionHash);
   }
 

--- a/src/TransactionProof.ts
+++ b/src/TransactionProof.ts
@@ -1,10 +1,26 @@
+import { TransactionProofChainItem, TransactionProofChainItemArray } from './TransactionProofChainItem.js';
+import { Base16Converter } from './util/Base16Converter.js';
+import { dedent } from './util/StringUtils.js';
+
+export type TransactionProofArray = readonly [Uint8Array, TransactionProofChainItemArray[], unknown];
+
 export class TransactionProof {
   public constructor(
-    public readonly transactionRecord: unknown,
-    public readonly transactionProof: unknown,
+    public readonly blockHeaderHash: Uint8Array,
+    public readonly chain: TransactionProofChainItem[],
+    public readonly unicityCertificate: unknown,
   ) {}
 
-  public toArray(): ReadonlyArray<unknown> {
-    return [this.transactionRecord, this.transactionProof];
+  public toArray(): TransactionProofArray {
+    return [this.blockHeaderHash, this.chain.map((item) => item.toArray()), this.unicityCertificate];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransactionProof
+        Block header hash: ${Base16Converter.encode(this.blockHeaderHash)}
+        Chain: [
+          ${this.chain.map((item) => item.toString()).join('\n')}
+        ]`;
   }
 }

--- a/src/TransactionProofChainItem.ts
+++ b/src/TransactionProofChainItem.ts
@@ -1,0 +1,21 @@
+import { Base16Converter } from './util/Base16Converter.js';
+import { dedent } from './util/StringUtils.js';
+
+export type TransactionProofChainItemArray = readonly [Uint8Array, boolean];
+export class TransactionProofChainItem {
+  public constructor(
+    public readonly hash: Uint8Array,
+    public readonly left: boolean,
+  ) {}
+
+  public toArray(): TransactionProofChainItemArray {
+    return [this.hash, this.left];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransactionProofChainItem
+        Hash: ${Base16Converter.encode(this.hash)}
+        Left: ${this.left}`;
+  }
+}

--- a/src/TransactionRecord.ts
+++ b/src/TransactionRecord.ts
@@ -1,0 +1,25 @@
+import { ServerMetadata, ServerMetadataArray } from './ServerMetadata.js';
+import { ITransactionPayloadAttributes } from './transaction/ITransactionPayloadAttributes.js';
+import { TransactionOrder, TransactionOrderArray } from './transaction/TransactionOrder.js';
+import { TransactionPayload } from './transaction/TransactionPayload.js';
+import { dedent } from './util/StringUtils.js';
+
+export type TransactionRecordArray = readonly [TransactionOrderArray, ServerMetadataArray];
+
+export class TransactionRecord<T extends TransactionPayload<ITransactionPayloadAttributes>> {
+  public constructor(
+    public readonly transactionOrder: TransactionOrder<T>,
+    public readonly serverMetadata: ServerMetadata,
+  ) {}
+
+  public toArray(): TransactionRecordArray {
+    return [this.transactionOrder.toArray(), this.serverMetadata.toArray()];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransactionRecord
+        ${this.transactionOrder.toString()}
+        ${this.serverMetadata.toString()}`;
+  }
+}

--- a/src/TransactionRecordWithProof.ts
+++ b/src/TransactionRecordWithProof.ts
@@ -1,0 +1,24 @@
+import { ITransactionPayloadAttributes } from './transaction/ITransactionPayloadAttributes.js';
+import { TransactionPayload } from './transaction/TransactionPayload.js';
+import { TransactionProof, TransactionProofArray } from './TransactionProof.js';
+import { TransactionRecord, TransactionRecordArray } from './TransactionRecord.js';
+import { dedent } from './util/StringUtils.js';
+
+export type TransactionRecordWithProofArray = readonly [TransactionRecordArray, TransactionProofArray];
+export class TransactionRecordWithProof<T extends TransactionPayload<ITransactionPayloadAttributes>> {
+  public constructor(
+    public readonly transactionRecord: TransactionRecord<T>,
+    public readonly transactionProof: TransactionProof,
+  ) {}
+
+  public toArray(): TransactionRecordWithProofArray {
+    return [this.transactionRecord.toArray(), this.transactionProof.toArray()];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransactionRecordWithProof
+        ${this.transactionRecord.toString()}
+        ${this.transactionProof.toString()}`;
+  }
+}

--- a/src/UnitId.ts
+++ b/src/UnitId.ts
@@ -1,4 +1,5 @@
 import { IUnitId } from './IUnitId.js';
+import { Base16Converter } from './util/Base16Converter.js';
 
 export class UnitId implements IUnitId {
   public constructor(
@@ -12,5 +13,9 @@ export class UnitId implements IUnitId {
 
   public getBytes(): Uint8Array {
     return new Uint8Array(this.bytes);
+  }
+
+  public toString(): string {
+    return `${Base16Converter.encode(this.bytes)}`;
   }
 }

--- a/src/codec/cbor/CborCodecNode.ts
+++ b/src/codec/cbor/CborCodecNode.ts
@@ -8,14 +8,16 @@ export class CborCodecNode implements ICborCodec {
       canonical: true,
       encodeUndefined: () => null,
       genTypes: {
-        Uint8Array: (encoder, data) => {
-          return encoder.pushAny(data.buffer);
+        Uint8Array: (encoder: cbor.Encoder, data: Uint8Array) => {
+          return encoder.pushAny(new Uint8Array(data).buffer);
         },
       },
     }) as Promise<Uint8Array>;
   }
 
   public decode(input: Uint8Array): Promise<unknown> {
-    return cbor.decodeFirst(input);
+    return cbor.decodeFirst(input, {
+      preferWeb: true,
+    });
   }
 }

--- a/src/codec/cbor/CborCodecWeb.ts
+++ b/src/codec/cbor/CborCodecWeb.ts
@@ -8,14 +8,16 @@ export class CborCodecWeb implements ICborCodec {
       canonical: true,
       encodeUndefined: () => null,
       genTypes: {
-        Uint8Array: (encoder, data) => {
-          return encoder.pushAny(data.buffer);
+        Uint8Array: (encoder: cbor.Encoder, data: Uint8Array) => {
+          return encoder.pushAny(new Uint8Array(data).buffer);
         },
       },
     }) as Promise<Uint8Array>;
   }
 
   public decode(input: Uint8Array): Promise<unknown> {
-    return cbor.decodeFirst(input);
+    return cbor.decodeFirst(input, {
+      preferWeb: true,
+    });
   }
 }

--- a/src/json-rpc/ITransactionProofFactory.ts
+++ b/src/json-rpc/ITransactionProofFactory.ts
@@ -1,0 +1,10 @@
+import { ITransactionPayloadAttributes } from '../transaction/ITransactionPayloadAttributes.js';
+import { TransactionPayload } from '../transaction/TransactionPayload.js';
+import { TransactionRecordWithProof } from '../TransactionRecordWithProof.js';
+import { TransactionProofDto } from './StateApiJsonRpcService.js';
+
+export interface ITransactionProofFactory {
+  create(
+    data: TransactionProofDto,
+  ): Promise<TransactionRecordWithProof<TransactionPayload<ITransactionPayloadAttributes>>>;
+}

--- a/src/json-rpc/IUnitDto.ts
+++ b/src/json-rpc/IUnitDto.ts
@@ -2,51 +2,37 @@ export interface IUnitDto {
   readonly unitId: string;
   readonly data: unknown;
   readonly ownerPredicate: string;
-  readonly stateProof: {
+  readonly stateProof?: IStateProofDto;
+}
+
+export interface IStateProofDto {
+  readonly unitId: string;
+  readonly unitValue: bigint;
+  readonly unitLedgerHash: string;
+  readonly unitTreeCert: IUnitTreeCertDto;
+  readonly stateTreeCert: IStateTreeCertDto;
+  // TODO: uncityCert has data inconsistent with other data formats, keeping it as is for now
+  readonly unicityCert: unknown;
+}
+
+export interface IUnitTreeCertDto {
+  readonly txrHash: string;
+  readonly dataHash: string;
+  readonly path: IPathItem[] | null;
+}
+
+export interface IStateTreeCertDto {
+  readonly leftSummaryHash: string;
+  readonly leftSummaryValue: bigint;
+  readonly rightSummaryHash: string;
+  readonly rightSummaryValue: bigint;
+  readonly path: {
     readonly unitId: string;
-    readonly unitValue: string;
-    readonly unitLedgerHash: string;
-    readonly unitTreeCert: {
-      readonly transactionRecordHash: string;
-      readonly unitDataHash: string;
-      readonly path: IPathItem[];
-    };
-    readonly stateTreeCert: {
-      readonly leftSummaryHash: string;
-      readonly LeftSummaryValue: string;
-      readonly rightSummaryHash: string;
-      readonly rightSummaryValue: string;
-      readonly path: {
-        readonly unitId: string;
-        readonly logsHash: string;
-        readonly value: string;
-        readonly siblingSummaryHash: string;
-        readonly siblingSummaryValue: string;
-      };
-    };
-    readonly unicityCertificate: {
-      readonly inputRecord: {
-        readonly previousHash: string;
-        readonly hash: string;
-        readonly blockHash: string;
-        readonly summaryValue: string;
-        readonly roundNumber: string;
-        readonly sumOfEarnedFees: string;
-      };
-      readonly unicityTreeCertificate: {
-        readonly systemIdentifier: string;
-        readonly siblingHashes: IPathItem[];
-        readonly systemDescriptionHash: string;
-      };
-      readonly unicitySeal: {
-        readonly rootChainRoundNumber: string;
-        readonly timestamp: string;
-        readonly previousHash: string;
-        readonly hash: string;
-        readonly signatures: Map<string, string>;
-      };
-    };
-  };
+    readonly logsHash: string;
+    readonly value: bigint;
+    readonly siblingSummaryHash: string;
+    readonly siblingSummaryValue: bigint;
+  }[];
 }
 
 interface IPathItem {

--- a/src/json-rpc/MoneyPartitionUnitFactory.ts
+++ b/src/json-rpc/MoneyPartitionUnitFactory.ts
@@ -1,10 +1,10 @@
 import { Bill } from '../Bill.js';
 import { FeeCreditRecord } from '../FeeCreditRecord.js';
-import { UnitType } from '../transaction/UnitType.js';
-import { IFeeCreditRecordDto } from './IFeeCreditRecordDto.js';
-import { IBillDataDto } from './IBillDataDto.js';
 import { IUnitId } from '../IUnitId.js';
+import { UnitType } from '../transaction/UnitType.js';
 import { Base16Converter } from '../util/Base16Converter.js';
+import { IBillDataDto } from './IBillDataDto.js';
+import { IFeeCreditRecordDto } from './IFeeCreditRecordDto.js';
 import { UnitFactory } from './UnitFactory.js';
 
 export class MoneyPartitionUnitFactory extends UnitFactory {

--- a/src/json-rpc/TokenPartitionUnitFactory.ts
+++ b/src/json-rpc/TokenPartitionUnitFactory.ts
@@ -1,13 +1,13 @@
-import { Base16Converter } from '../util/Base16Converter.js';
-import { UnitType } from '../transaction/UnitType.js';
 import { FeeCreditRecord } from '../FeeCreditRecord.js';
-import { IFeeCreditRecordDto } from './IFeeCreditRecordDto.js';
-import { IUnitId } from '../IUnitId.js';
-import { UnitFactory } from './UnitFactory.js';
-import { NonFungibleToken } from '../NonFungibleToken.js';
-import { INonFungibleTokenDto } from './INonFungibleTokenDto.js';
 import { FungibleToken } from '../FungibleToken.js';
+import { IUnitId } from '../IUnitId.js';
+import { NonFungibleToken } from '../NonFungibleToken.js';
+import { UnitType } from '../transaction/UnitType.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { IFeeCreditRecordDto } from './IFeeCreditRecordDto.js';
 import { IFungibleTokenDto } from './IFungibleTokenDto.js';
+import { INonFungibleTokenDto } from './INonFungibleTokenDto.js';
+import { UnitFactory } from './UnitFactory.js';
 
 export class TokenPartitionUnitFactory extends UnitFactory {
   private static readonly FUNGIBLE_TOKEN_HEX = Base16Converter.encode(

--- a/src/json-rpc/TransactionProofFactory.ts
+++ b/src/json-rpc/TransactionProofFactory.ts
@@ -1,0 +1,435 @@
+import { ICborCodec } from '../codec/cbor/ICborCodec.js';
+import { PredicateBytes } from '../PredicateBytes.js';
+import { ServerMetadata, ServerMetadataArray } from '../ServerMetadata.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { AddFeeCreditAttributes, AddFeeCreditAttributesArray } from '../transaction/AddFeeCreditAttributes.js';
+import { AddFeeCreditPayload } from '../transaction/AddFeeCreditPayload.js';
+import {
+  BurnFungibleTokenAttributes,
+  BurnFungibleTokenAttributesArray,
+} from '../transaction/BurnFungibleTokenAttributes.js';
+import { BurnFungibleTokenPayload } from '../transaction/BurnFungibleTokenPayload.js';
+import { CloseFeeCreditAttributes, CloseFeeCreditAttributesArray } from '../transaction/CloseFeeCreditAttributes.js';
+import { CloseFeeCreditPayload } from '../transaction/CloseFeeCreditPayload.js';
+import {
+  CreateFungibleTokenAttributes,
+  CreateFungibleTokenAttributesArray,
+} from '../transaction/CreateFungibleTokenAttributes.js';
+import { CreateFungibleTokenPayload } from '../transaction/CreateFungibleTokenPayload.js';
+import {
+  CreateFungibleTokenTypeAttributes,
+  CreateFungibleTokenTypeAttributesArray,
+} from '../transaction/CreateFungibleTokenTypeAttributes.js';
+import { CreateFungibleTokenTypePayload } from '../transaction/CreateFungibleTokenTypePayload.js';
+import {
+  CreateNonFungibleTokenAttributes,
+  CreateNonFungibleTokenAttributesArray,
+} from '../transaction/CreateNonFungibleTokenAttributes.js';
+import { CreateNonFungibleTokenPayload } from '../transaction/CreateNonFungibleTokenPayload.js';
+import {
+  CreateNonFungibleTokenTypeAttributes,
+  CreateNonFungibleTokenTypeAttributesArray,
+} from '../transaction/CreateNonFungibleTokenTypeAttributes.js';
+import { CreateNonFungibleTokenTypePayload } from '../transaction/CreateNonFungibleTokenTypePayload.js';
+import { FeeCreditUnitId } from '../transaction/FeeCreditUnitId.js';
+import { ITransactionPayloadAttributes } from '../transaction/ITransactionPayloadAttributes.js';
+import { LockBillAttributes, LockBillAttributesArray } from '../transaction/LockBillAttributes.js';
+import { LockBillPayload } from '../transaction/LockBillPayload.js';
+import { NonFungibleTokenData } from '../transaction/NonFungibleTokenData.js';
+import {
+  ReclaimFeeCreditAttributes,
+  ReclaimFeeCreditAttributesArray,
+} from '../transaction/ReclaimFeeCreditAttributes.js';
+import { ReclaimFeeCreditPayload } from '../transaction/ReclaimFeeCreditPayload.js';
+import { SplitBillAttributes, SplitBillAttributesArray } from '../transaction/SplitBillAttributes.js';
+import { SplitBillPayload } from '../transaction/SplitBillPayload.js';
+import { SplitBillUnit } from '../transaction/SplitBillUnit.js';
+import {
+  SplitFungibleTokenAttributes,
+  SplitFungibleTokenAttributesArray,
+} from '../transaction/SplitFungibleTokenAttributes.js';
+import { SplitFungibleTokenPayload } from '../transaction/SplitFungibleTokenPayload.js';
+import {
+  SwapBillsWithDustCollectorAttributes,
+  SwapBillsWithDustCollectorAttributesArray,
+} from '../transaction/SwapBillsWithDustCollectorAttributes.js';
+import { SwapBillsWithDustCollectorPayload } from '../transaction/SwapBillsWithDustCollectorPayload.js';
+import { TokenIcon } from '../transaction/TokenIcon.js';
+import { TransactionOrder, TransactionOrderArray } from '../transaction/TransactionOrder.js';
+import { TransactionOrderFactory } from '../transaction/TransactionOrderFactory.js';
+import { TransactionPayload, TransactionPayloadArray } from '../transaction/TransactionPayload.js';
+import { TransferBillAttributes, TransferBillAttributesArray } from '../transaction/TransferBillAttributes.js';
+import { TransferBillToDustCollectorPayload } from '../transaction/TransferBillDustCollectorPayload.js';
+import { TransferBillPayload } from '../transaction/TransferBillPayload.js';
+import {
+  TransferBillToDustCollectorAttributes,
+  TransferBillToDustCollectorAttributesArray,
+} from '../transaction/TransferBillToDustCollectorAttributes.js';
+import {
+  TransferFeeCreditAttributes,
+  TransferFeeCreditAttributesArray,
+} from '../transaction/TransferFeeCreditAttributes.js';
+import { TransferFeeCreditPayload } from '../transaction/TransferFeeCreditPayload.js';
+import {
+  TransferFungibleTokenAttributes,
+  TransferFungibleTokenAttributesArray,
+} from '../transaction/TransferFungibleTokenAttributes.js';
+import { TransferFungibleTokenPayload } from '../transaction/TransferFungibleTokenPayload.js';
+import {
+  TransferNonFungibleTokenAttributes,
+  TransferNonFungibleTokenAttributesArray,
+} from '../transaction/TransferNonFungibleTokenAttributes.js';
+import { TransferNonFungibleTokenPayload } from '../transaction/TransferNonFungibleTokenPayload.js';
+import { UnlockBillAttributes, UnlockBillAttributesArray } from '../transaction/UnlockBillAttributes.js';
+import { UnlockBillPayload } from '../transaction/UnlockBillPayload.js';
+import {
+  UpdateNonFungibleTokenAttributes,
+  UpdateNonFungibleTokenAttributesArray,
+} from '../transaction/UpdateNonFungibleTokenAttributes.js';
+import { UpdateNonFungibleTokenPayload } from '../transaction/UpdateNonFungibleTokenPayload.js';
+import { TransactionProof, TransactionProofArray } from '../TransactionProof.js';
+import { TransactionProofChainItem } from '../TransactionProofChainItem.js';
+import { TransactionRecord, TransactionRecordArray } from '../TransactionRecord.js';
+import { TransactionRecordWithProof } from '../TransactionRecordWithProof.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { ITransactionProofFactory } from './ITransactionProofFactory.js';
+import { IUnitFactory } from './IUnitFactory.js';
+import { TransactionProofDto } from './StateApiJsonRpcService.js';
+
+export class TransactionProofFactory implements ITransactionProofFactory {
+  private createPayloadAttributesMap = new Map<string, (data: unknown) => Promise<ITransactionPayloadAttributes>>([
+    [AddFeeCreditPayload.PAYLOAD_TYPE, this.createAddFeeCreditAttributes.bind(this)],
+    [BurnFungibleTokenPayload.PAYLOAD_TYPE, this.createBurnFungibleTokenAttributes.bind(this)],
+    [CloseFeeCreditPayload.PAYLOAD_TYPE, this.createCloseFeeCreditAttributes.bind(this)],
+    [CreateFungibleTokenPayload.PAYLOAD_TYPE, this.createCreateFungibleTokenAttributes.bind(this)],
+    [CreateFungibleTokenTypePayload.PAYLOAD_TYPE, this.createCreateFungibleTokenTypeAttributes.bind(this)],
+    [CreateNonFungibleTokenPayload.PAYLOAD_TYPE, this.createCreateNonFungibleTokenAttributes.bind(this)],
+    [CreateNonFungibleTokenTypePayload.PAYLOAD_TYPE, this.createCreateNonFungibleTokenTypeAttributes.bind(this)],
+    [LockBillPayload.PAYLOAD_TYPE, this.createLockBillAttributes.bind(this)],
+    [ReclaimFeeCreditPayload.PAYLOAD_TYPE, this.createReclaimFeeCreditAttributes.bind(this)],
+    [SplitBillPayload.PAYLOAD_TYPE, this.createSplitBillAttributes.bind(this)],
+    [SplitFungibleTokenPayload.PAYLOAD_TYPE, this.createSplitFungibleTokenAttributes.bind(this)],
+    [SwapBillsWithDustCollectorPayload.PAYLOAD_TYPE, this.createSwapBillsWithDustCollectorAttributes.bind(this)],
+    [TransferBillPayload.PAYLOAD_TYPE, this.createTransferBillAttributes.bind(this)],
+    [TransferBillToDustCollectorPayload.PAYLOAD_TYPE, this.createTransferBillToDustCollectorAttributes.bind(this)],
+    [TransferFeeCreditPayload.PAYLOAD_TYPE, this.createTransferFeeCreditAttributes.bind(this)],
+    [TransferFungibleTokenPayload.PAYLOAD_TYPE, this.createTransferFungibleTokenAttributes.bind(this)],
+    [TransferNonFungibleTokenPayload.PAYLOAD_TYPE, this.createTransferNonFungibleTokenAttributes.bind(this)],
+    [UnlockBillPayload.PAYLOAD_TYPE, this.createUnlockBillAttributes.bind(this)],
+    [UpdateNonFungibleTokenPayload.PAYLOAD_TYPE, this.createUpdateNonFungibleTokenAttributes.bind(this)],
+  ]);
+
+  public constructor(
+    private readonly cborCodec: ICborCodec,
+    private readonly unitFactory: IUnitFactory,
+  ) {}
+
+  public async create({
+    txRecord,
+    txProof,
+  }: TransactionProofDto): Promise<TransactionRecordWithProof<TransactionPayload<ITransactionPayloadAttributes>>> {
+    return this.createTransactionRecordWithProof(
+      (await this.cborCodec.decode(Base16Converter.decode(txRecord))) as TransactionRecordArray,
+      (await this.cborCodec.decode(Base16Converter.decode(txProof))) as TransactionProofArray,
+    );
+  }
+
+  private async createTransactionRecordWithProof(
+    transactionRecord: TransactionRecordArray,
+    transactionProof: TransactionProofArray,
+  ): Promise<TransactionRecordWithProof<TransactionPayload<ITransactionPayloadAttributes>>> {
+    return new TransactionRecordWithProof(
+      await this.createTransactionRecord(transactionRecord),
+      await this.createTransactionProof(transactionProof),
+    );
+  }
+
+  private async createTransactionRecord([transactionOrder, serverMetadata]: TransactionRecordArray): Promise<
+    TransactionRecord<TransactionPayload<ITransactionPayloadAttributes>>
+  > {
+    return new TransactionRecord(
+      await this.createTransactionOrder(transactionOrder),
+      await this.createServerMetadata(serverMetadata),
+    );
+  }
+
+  private async createTransactionProof([
+    blockHeaderHash,
+    chain,
+    unicityCertificate,
+  ]: TransactionProofArray): Promise<TransactionProof> {
+    return new TransactionProof(
+      blockHeaderHash,
+      chain.map((item) => new TransactionProofChainItem(item[0], item[1])),
+      unicityCertificate,
+    );
+  }
+
+  private async createTransactionOrder([transactionPayload, ownerProof, feeProof]: TransactionOrderArray): Promise<
+    TransactionOrder<TransactionPayload<ITransactionPayloadAttributes>>
+  > {
+    return TransactionOrderFactory.createTransactionOrder(
+      await this.createTransactionPayload(transactionPayload),
+      ownerProof,
+      feeProof ? feeProof : null,
+      this.cborCodec,
+    );
+  }
+
+  private async createTransactionPayload([
+    systemIdentifier,
+    type,
+    unitId,
+    attributes,
+    clientMetadata,
+  ]: TransactionPayloadArray): Promise<TransactionPayload<ITransactionPayloadAttributes>> {
+    return new TransactionPayload(
+      type,
+      systemIdentifier,
+      this.unitFactory.createUnitId(unitId),
+      await this.createTransactionPayloadAttributes(type, attributes),
+      {
+        timeout: BigInt(clientMetadata[0]),
+        maxTransactionFee: BigInt(clientMetadata[1]),
+        feeCreditRecordId: clientMetadata[2] ? this.unitFactory.createUnitId(clientMetadata[2]) : null,
+      },
+    );
+  }
+
+  private async createServerMetadata([
+    actualFee,
+    targetUnits,
+    successIndicator,
+    processingDetails,
+  ]: ServerMetadataArray): Promise<ServerMetadata> {
+    return new ServerMetadata(
+      BigInt(actualFee),
+      targetUnits.map((id) => id),
+      BigInt(successIndicator),
+      processingDetails ? processingDetails : null,
+    );
+  }
+
+  private async createTransactionPayloadAttributes(
+    type: string,
+    data: unknown,
+  ): Promise<ITransactionPayloadAttributes> {
+    if (!this.createPayloadAttributesMap.has(type)) {
+      throw new Error(`Could not parse transaction payload attributes for ${type}.`);
+    }
+
+    return this.createPayloadAttributesMap.get(type)?.(data) as Promise<ITransactionPayloadAttributes>;
+  }
+
+  private async createAddFeeCreditAttributes(data: AddFeeCreditAttributesArray): Promise<AddFeeCreditAttributes> {
+    return new AddFeeCreditAttributes(
+      new PredicateBytes(data[0]),
+      (await this.createTransactionRecordWithProof(
+        data[1],
+        data[2],
+      )) as TransactionRecordWithProof<TransferFeeCreditPayload>,
+    );
+  }
+
+  private async createBurnFungibleTokenAttributes(
+    data: BurnFungibleTokenAttributesArray,
+  ): Promise<BurnFungibleTokenAttributes> {
+    return new BurnFungibleTokenAttributes(
+      this.unitFactory.createUnitId(data[0] as Uint8Array),
+      BigInt(data[1]),
+      this.unitFactory.createUnitId(data[2]),
+      data[3],
+      data[4],
+      data[5] ? data[5].map((signature) => signature) : null,
+    );
+  }
+
+  private async createCloseFeeCreditAttributes(data: CloseFeeCreditAttributesArray): Promise<CloseFeeCreditAttributes> {
+    return new CloseFeeCreditAttributes(BigInt(data[0]), this.unitFactory.createUnitId(data[1]), data[2]);
+  }
+
+  private async createCreateFungibleTokenAttributes(
+    data: CreateFungibleTokenAttributesArray,
+  ): Promise<CreateFungibleTokenAttributes> {
+    return new CreateFungibleTokenAttributes(
+      new PredicateBytes(data[0]),
+      this.unitFactory.createUnitId(data[1]),
+      BigInt(data[2]),
+      data[3] || null,
+    );
+  }
+
+  private async createCreateFungibleTokenTypeAttributes(
+    data: CreateFungibleTokenTypeAttributesArray,
+  ): Promise<CreateFungibleTokenTypeAttributes> {
+    return new CreateFungibleTokenTypeAttributes(
+      data[0],
+      data[1],
+      new TokenIcon(data[2][0], data[2][1]),
+      data[3] ? this.unitFactory.createUnitId(data[3]) : null,
+      data[4],
+      new PredicateBytes(data[5]),
+      new PredicateBytes(data[6]),
+      new PredicateBytes(data[7]),
+      data[8] || null,
+    );
+  }
+
+  private async createCreateNonFungibleTokenAttributes(
+    data: CreateNonFungibleTokenAttributesArray,
+  ): Promise<CreateNonFungibleTokenAttributes> {
+    return new CreateNonFungibleTokenAttributes(
+      new PredicateBytes(data[0]),
+      this.unitFactory.createUnitId(data[1]),
+      data[2],
+      data[3],
+      NonFungibleTokenData.CreateFromBytes(data[4]),
+      new PredicateBytes(data[5]),
+      data[6] || null,
+    );
+  }
+
+  private async createCreateNonFungibleTokenTypeAttributes(
+    data: CreateNonFungibleTokenTypeAttributesArray,
+  ): Promise<CreateNonFungibleTokenTypeAttributes> {
+    return new CreateNonFungibleTokenTypeAttributes(
+      data[0],
+      data[1],
+      new TokenIcon(data[2][0], data[2][1]),
+      data[3] ? this.unitFactory.createUnitId(data[3]) : null,
+      new PredicateBytes(data[4]),
+      new PredicateBytes(data[5]),
+      new PredicateBytes(data[6]),
+      new PredicateBytes(data[7]),
+      data[8] || null,
+    );
+  }
+
+  private async createLockBillAttributes(data: LockBillAttributesArray): Promise<LockBillAttributes> {
+    return new LockBillAttributes(BigInt(data[0]), data[1]);
+  }
+
+  private async createReclaimFeeCreditAttributes(
+    data: ReclaimFeeCreditAttributesArray,
+  ): Promise<ReclaimFeeCreditAttributes> {
+    return new ReclaimFeeCreditAttributes(
+      (await this.createTransactionRecordWithProof(
+        data[0],
+        data[1],
+      )) as TransactionRecordWithProof<CloseFeeCreditPayload>,
+      data[2],
+    );
+  }
+
+  private async createSplitBillAttributes(data: SplitBillAttributesArray): Promise<SplitBillAttributes> {
+    return new SplitBillAttributes(
+      data[0].map((unit) => new SplitBillUnit(BigInt(unit[0]), new PredicateBytes(unit[1]))),
+      BigInt(data[1]),
+      data[2],
+    );
+  }
+
+  private async createSplitFungibleTokenAttributes(
+    data: SplitFungibleTokenAttributesArray,
+  ): Promise<SplitFungibleTokenAttributes> {
+    return new SplitFungibleTokenAttributes(
+      new PredicateBytes(data[0]),
+      BigInt(data[1]),
+      data[2] || null,
+      data[3],
+      this.unitFactory.createUnitId(data[4]),
+      BigInt(data[5]),
+      data[6] || null,
+    );
+  }
+
+  private async createSwapBillsWithDustCollectorAttributes(
+    data: SwapBillsWithDustCollectorAttributesArray,
+  ): Promise<SwapBillsWithDustCollectorAttributes> {
+    const transactionRecordWithProof = new Array<
+      Promise<TransactionRecordWithProof<TransferBillToDustCollectorPayload>>
+    >();
+
+    for (let i = 0; i < data[1].length; i++) {
+      transactionRecordWithProof.push(
+        this.createTransactionRecordWithProof(data[1][i], data[2][i]) as Promise<
+          TransactionRecordWithProof<TransferBillToDustCollectorPayload>
+        >,
+      );
+    }
+
+    return new SwapBillsWithDustCollectorAttributes(
+      new PredicateBytes(data[0]),
+      await Promise.all(transactionRecordWithProof),
+      BigInt(data[3]),
+    );
+  }
+
+  private async createTransferBillAttributes(data: TransferBillAttributesArray): Promise<TransferBillAttributes> {
+    return new TransferBillAttributes(new PredicateBytes(data[0]), BigInt(data[1]), data[2]);
+  }
+
+  private async createTransferBillToDustCollectorAttributes(
+    data: TransferBillToDustCollectorAttributesArray,
+  ): Promise<TransferBillToDustCollectorAttributes> {
+    return new TransferBillToDustCollectorAttributes(
+      BigInt(data[0]),
+      this.unitFactory.createUnitId(data[1]),
+      data[2],
+      data[3],
+    );
+  }
+
+  private async createTransferFeeCreditAttributes(
+    data: TransferFeeCreditAttributesArray,
+  ): Promise<TransferFeeCreditAttributes> {
+    return new TransferFeeCreditAttributes(
+      BigInt(data[0]),
+      data[1] as unknown as SystemIdentifier,
+      this.unitFactory.createUnitId(data[2]) as FeeCreditUnitId,
+      BigInt(data[3]),
+      BigInt(data[4]),
+      data[5] || null,
+      data[6],
+    );
+  }
+
+  private async createTransferFungibleTokenAttributes(
+    data: TransferFungibleTokenAttributesArray,
+  ): Promise<TransferFungibleTokenAttributes> {
+    return new TransferFungibleTokenAttributes(
+      new PredicateBytes(data[0]),
+      BigInt(data[1]),
+      BigInt(data[2]),
+      data[3],
+      this.unitFactory.createUnitId(data[4]),
+      data[5] || null,
+    );
+  }
+
+  private async createTransferNonFungibleTokenAttributes(
+    data: TransferNonFungibleTokenAttributesArray,
+  ): Promise<TransferNonFungibleTokenAttributes> {
+    return new TransferNonFungibleTokenAttributes(
+      new PredicateBytes(data[0]),
+      data[1] || null,
+      data[2],
+      this.unitFactory.createUnitId(data[3]),
+      data[4] || null,
+    );
+  }
+
+  private async createUnlockBillAttributes(data: UnlockBillAttributesArray): Promise<UnlockBillAttributes> {
+    return new UnlockBillAttributes(data[0]);
+  }
+
+  private async createUpdateNonFungibleTokenAttributes(
+    data: UpdateNonFungibleTokenAttributesArray,
+  ): Promise<UpdateNonFungibleTokenAttributes> {
+    return new UpdateNonFungibleTokenAttributes(
+      NonFungibleTokenData.CreateFromBytes(data[0]),
+      data[1],
+      data[2] || null,
+    );
+  }
+}

--- a/src/json-rpc/UnitFactory.ts
+++ b/src/json-rpc/UnitFactory.ts
@@ -1,9 +1,9 @@
-import { IUnitFactory } from './IUnitFactory.js';
+import { IStateProof, IStateTreeCert, IUnit, IUnitTreeCert } from '../IUnit.js';
 import { IUnitId } from '../IUnitId.js';
-import { IUnitDto } from './IUnitDto.js';
-import { IUnit } from '../IUnit.js';
-import { Base16Converter } from '../util/Base16Converter.js';
 import { UnitId } from '../UnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { IStateProofDto, IStateTreeCertDto, IUnitDto, IUnitTreeCertDto } from './IUnitDto.js';
+import { IUnitFactory } from './IUnitFactory.js';
 
 export abstract class UnitFactory implements IUnitFactory {
   public static createUnitIdFromBytes(id: Uint8Array): IUnitId {
@@ -15,15 +15,56 @@ export abstract class UnitFactory implements IUnitFactory {
   }
 
   public async createUnit(data: IUnitDto): Promise<IUnit<unknown>> {
-    const unitId = this.createUnitId(Base16Converter.decode(data.unitId.substring(2)));
+    const unitId = this.createUnitId(Base16Converter.decode(data.unitId));
     return {
       unitId,
       data: await this.createUnitData(unitId, data.data),
       ownerPredicate: Base16Converter.decode(data.ownerPredicate),
-      // TODO: Parse stateproof
-      stateProof: undefined,
+      stateProof: data.stateProof ? this.createStateProof(data.stateProof) : null,
     };
   }
 
   protected abstract createUnitData(unitId: IUnitId, data: unknown): Promise<unknown>;
+
+  // TODO: Parse unicity cert
+  private createStateProof(data: IStateProofDto): IStateProof {
+    return {
+      unitId: this.createUnitId(Base16Converter.decode(data.unitId)),
+      unitValue: BigInt(data.unitValue),
+      unitLedgerHash: Base16Converter.decode(data.unitLedgerHash),
+      unitTreeCert: this.createUnitTreeCert(data.unitTreeCert),
+      stateTreeCert: this.createStateTreeCert(data.stateTreeCert),
+      unicityCertificate: data.unicityCert,
+    };
+  }
+
+  private createStateTreeCert(data: IStateTreeCertDto): IStateTreeCert {
+    return {
+      leftSummaryHash: Base16Converter.decode(data.leftSummaryHash),
+      leftSummaryValue: BigInt(data.leftSummaryValue),
+      rightSummaryHash: Base16Converter.decode(data.rightSummaryHash),
+      rightSummaryValue: BigInt(data.rightSummaryValue),
+      path: data.path.map((path) => {
+        return {
+          unitId: this.createUnitId(Base16Converter.decode(path.unitId)),
+          logsHash: Base16Converter.decode(path.logsHash),
+          value: BigInt(path.value),
+          siblingSummaryHash: Base16Converter.decode(path.siblingSummaryHash),
+          siblingSummaryValue: BigInt(path.siblingSummaryValue),
+        };
+      }),
+    };
+  }
+
+  private createUnitTreeCert(data: IUnitTreeCertDto): IUnitTreeCert {
+    return {
+      transactionRecordHash: Base16Converter.decode(data.txrHash),
+      unitDataHash: Base16Converter.decode(data.dataHash),
+      path:
+        data.path?.map((item) => ({
+          hash: Base16Converter.decode(item.hash),
+          directionLeft: item.directionLeft,
+        })) || null,
+    };
+  }
 }

--- a/src/transaction/AddFeeCreditAttributes.ts
+++ b/src/transaction/AddFeeCreditAttributes.ts
@@ -1,18 +1,29 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TransactionRecordWithProof, TransactionRecordWithProofArray } from '../TransactionRecordWithProof.js';
+import { dedent } from '../util/StringUtils.js';
 import { IPredicate } from './IPredicate.js';
-import { TransactionProof } from '../TransactionProof.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TransferFeeCreditPayload } from './TransferFeeCreditPayload.js';
+
+export type AddFeeCreditAttributesArray = [Uint8Array, ...TransactionRecordWithProofArray];
 
 export class AddFeeCreditAttributes implements ITransactionPayloadAttributes {
   public constructor(
     public readonly ownerPredicate: IPredicate,
-    public readonly transactionProof: TransactionProof,
+    public readonly transactionProof: TransactionRecordWithProof<TransferFeeCreditPayload>,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): AddFeeCreditAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): AddFeeCreditAttributesArray {
     return [this.ownerPredicate.getBytes(), ...this.transactionProof.toArray()];
+  }
+
+  public toString(): string {
+    return dedent`
+      AddFeeCreditAttributes
+        Owner Predicate: ${this.ownerPredicate.toString()}
+        Transaction Proof: ${this.transactionProof.toString()}`;
   }
 }

--- a/src/transaction/AddFeeCreditPayload.ts
+++ b/src/transaction/AddFeeCreditPayload.ts
@@ -1,8 +1,8 @@
-import { FeeCreditPayload } from './FeeCreditPayload.js';
-import { AddFeeCreditAttributes } from './AddFeeCreditAttributes.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
-import { FeeCreditClientMetadata } from './FeeCreditClientMetadata.js';
 import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { AddFeeCreditAttributes } from './AddFeeCreditAttributes.js';
+import { FeeCreditClientMetadata } from './FeeCreditClientMetadata.js';
+import { FeeCreditPayload } from './FeeCreditPayload.js';
 
 export class AddFeeCreditPayload extends FeeCreditPayload<AddFeeCreditAttributes> {
   public static readonly PAYLOAD_TYPE = 'addFC';

--- a/src/transaction/AlwaysTruePredicate.ts
+++ b/src/transaction/AlwaysTruePredicate.ts
@@ -4,4 +4,8 @@ export class AlwaysTruePredicate implements IPredicate {
   public getBytes(): Uint8Array {
     return new Uint8Array([0x83, 0x00, 0x41, 0x01, 0xf6]);
   }
+
+  public toString(): string {
+    return 'AlwaysTruePredicate';
+  }
 }

--- a/src/transaction/BurnFungibleTokenAttributes.ts
+++ b/src/transaction/BurnFungibleTokenAttributes.ts
@@ -1,5 +1,16 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type BurnFungibleTokenAttributesArray = readonly [
+  Uint8Array,
+  bigint,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array[] | null,
+];
 
 export class BurnFungibleTokenAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -11,7 +22,7 @@ export class BurnFungibleTokenAttributes implements ITransactionPayloadAttribute
     public readonly invariantPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): BurnFungibleTokenAttributesArray {
     return [
       this.typeId.getBytes(),
       this.value,
@@ -22,7 +33,7 @@ export class BurnFungibleTokenAttributes implements ITransactionPayloadAttribute
     ];
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): BurnFungibleTokenAttributesArray {
     return [
       this.typeId.getBytes(),
       this.value,
@@ -31,5 +42,18 @@ export class BurnFungibleTokenAttributes implements ITransactionPayloadAttribute
       this.backlink,
       this.invariantPredicateSignatures,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      BurnFungibleTokenAttributes
+        Type ID: ${this.typeId.toString()}
+        Value: ${this.value}
+        Target Token ID: ${this.targetTokenId.toString()}
+        Target Token Backlink: ${Base16Converter.encode(this.targetTokenBacklink)}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Invariant Predicate Signatures: [
+          ${this.invariantPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/BurnFungibleTokenPayload.ts
+++ b/src/transaction/BurnFungibleTokenPayload.ts
@@ -1,8 +1,8 @@
-import { TransactionPayload } from './TransactionPayload.js';
 import { IUnitId } from '../IUnitId.js';
-import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
 import { BurnFungibleTokenAttributes } from './BurnFungibleTokenAttributes.js';
+import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class BurnFungibleTokenPayload extends TransactionPayload<BurnFungibleTokenAttributes> {
   public static readonly PAYLOAD_TYPE = 'burnFToken';

--- a/src/transaction/CloseFeeCreditAttributes.ts
+++ b/src/transaction/CloseFeeCreditAttributes.ts
@@ -1,0 +1,30 @@
+import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type CloseFeeCreditAttributesArray = readonly [bigint, Uint8Array, Uint8Array];
+
+export class CloseFeeCreditAttributes implements ITransactionPayloadAttributes {
+  public constructor(
+    public readonly amount: bigint,
+    public readonly targetUnitId: IUnitId,
+    public readonly targetUnitBacklink: Uint8Array,
+  ) {}
+
+  public toOwnerProofData(): CloseFeeCreditAttributesArray {
+    return this.toArray();
+  }
+
+  public toArray(): CloseFeeCreditAttributesArray {
+    return [this.amount, this.targetUnitId.getBytes(), this.targetUnitBacklink];
+  }
+
+  public toString(): string {
+    return dedent`
+      CloseFeeCreditAttributes
+        Amount: ${this.amount}
+        Target Unit ID: ${this.targetUnitId.toString()}
+        Target Unit Backlink: ${Base16Converter.encode(this.targetUnitBacklink)}`;
+  }
+}

--- a/src/transaction/CloseFeeCreditPayload.ts
+++ b/src/transaction/CloseFeeCreditPayload.ts
@@ -1,0 +1,18 @@
+import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { CloseFeeCreditAttributes } from './CloseFeeCreditAttributes.js';
+import { FeeCreditClientMetadata } from './FeeCreditClientMetadata.js';
+import { FeeCreditPayload } from './FeeCreditPayload.js';
+
+export class CloseFeeCreditPayload extends FeeCreditPayload<CloseFeeCreditAttributes> {
+  public static readonly PAYLOAD_TYPE = 'closeFC';
+
+  public constructor(
+    attributes: CloseFeeCreditAttributes,
+    systemIdentifier: SystemIdentifier,
+    unitId: IUnitId,
+    clientMetadata: FeeCreditClientMetadata,
+  ) {
+    super(CloseFeeCreditPayload.PAYLOAD_TYPE, systemIdentifier, unitId, attributes, clientMetadata);
+  }
+}

--- a/src/transaction/CreateFungibleTokenAttributes.ts
+++ b/src/transaction/CreateFungibleTokenAttributes.ts
@@ -1,6 +1,10 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { IPredicate } from './IPredicate.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type CreateFungibleTokenAttributesArray = readonly [Uint8Array, Uint8Array, bigint, Uint8Array[] | null];
 
 export class CreateFungibleTokenAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -10,11 +14,22 @@ export class CreateFungibleTokenAttributes implements ITransactionPayloadAttribu
     public readonly tokenCreationPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): CreateFungibleTokenAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): CreateFungibleTokenAttributesArray {
     return [this.ownerPredicate.getBytes(), this.typeId.getBytes(), this.value, this.tokenCreationPredicateSignatures];
+  }
+
+  public toString(): string {
+    return dedent`
+      CreateFungibleTokenAttributes
+        Owner Predicate: ${this.ownerPredicate.toString()}
+        Type ID: ${this.typeId.toString()}
+        Value: ${this.value}
+        Token Creation Predicate Signatures: [
+          ${this.tokenCreationPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/CreateFungibleTokenPayload.ts
+++ b/src/transaction/CreateFungibleTokenPayload.ts
@@ -1,8 +1,8 @@
-import { CreateFungibleTokenAttributes } from './CreateFungibleTokenAttributes.js';
-import { TransactionPayload } from './TransactionPayload.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
 import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { CreateFungibleTokenAttributes } from './CreateFungibleTokenAttributes.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class CreateFungibleTokenPayload extends TransactionPayload<CreateFungibleTokenAttributes> {
   public static readonly PAYLOAD_TYPE = 'createFToken';

--- a/src/transaction/CreateFungibleTokenTypeAttributes.ts
+++ b/src/transaction/CreateFungibleTokenTypeAttributes.ts
@@ -1,7 +1,21 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { TokenIcon } from './TokenIcon.js';
-import { IPredicate } from './IPredicate.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TokenIcon, TokenIconArray } from './TokenIcon.js';
+
+export type CreateFungibleTokenTypeAttributesArray = readonly [
+  string,
+  string,
+  TokenIconArray,
+  Uint8Array | null,
+  number,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array[] | null,
+];
 
 export class CreateFungibleTokenTypeAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -16,11 +30,11 @@ export class CreateFungibleTokenTypeAttributes implements ITransactionPayloadAtt
     public readonly subTypeCreationPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): CreateFungibleTokenTypeAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): CreateFungibleTokenTypeAttributesArray {
     return [
       this.symbol,
       this.name,
@@ -32,5 +46,21 @@ export class CreateFungibleTokenTypeAttributes implements ITransactionPayloadAtt
       this.invariantPredicate.getBytes(),
       this.subTypeCreationPredicateSignatures,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      CreateFungibleTokenTypeAttributes
+        Symbol: ${this.symbol}
+        Name: ${this.name}
+        Icon: ${this.icon.toString()}
+        Parent Type ID: ${this.parentTypeId?.toString() ?? 'null'}
+        Decimal Places: ${this.decimalPlaces}
+        Sub Type Creation Predicate: ${this.subTypeCreationPredicate.toString()}
+        Token Creation Predicate: ${this.tokenCreationPredicate.toString()}
+        Invariant Predicate: ${this.invariantPredicate.toString()}
+        Sub Type Creation Predicate Signatures: [
+          ${this.subTypeCreationPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/CreateFungibleTokenTypePayload.ts
+++ b/src/transaction/CreateFungibleTokenTypePayload.ts
@@ -1,8 +1,8 @@
-import { CreateFungibleTokenTypeAttributes } from './CreateFungibleTokenTypeAttributes.js';
-import { TransactionPayload } from './TransactionPayload.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
 import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { CreateFungibleTokenTypeAttributes } from './CreateFungibleTokenTypeAttributes.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class CreateFungibleTokenTypePayload extends TransactionPayload<CreateFungibleTokenTypeAttributes> {
   public static readonly PAYLOAD_TYPE = 'createFType';

--- a/src/transaction/CreateNonFungibleTokenAttributes.ts
+++ b/src/transaction/CreateNonFungibleTokenAttributes.ts
@@ -1,7 +1,19 @@
-import { INonFungibleTokenData } from './INonFungibleTokenData.js';
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { IPredicate } from './IPredicate.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { INonFungibleTokenData } from './INonFungibleTokenData.js';
+import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type CreateNonFungibleTokenAttributesArray = readonly [
+  Uint8Array,
+  Uint8Array,
+  string,
+  string,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array[] | null,
+];
 
 export class CreateNonFungibleTokenAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -14,11 +26,11 @@ export class CreateNonFungibleTokenAttributes implements ITransactionPayloadAttr
     public readonly tokenCreationPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): CreateNonFungibleTokenAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): CreateNonFungibleTokenAttributesArray {
     return [
       this.ownerPredicate.getBytes(),
       this.typeId.getBytes(),
@@ -28,5 +40,19 @@ export class CreateNonFungibleTokenAttributes implements ITransactionPayloadAttr
       this.dataUpdatePredicate.getBytes(),
       this.tokenCreationPredicateSignatures,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      CreateNonFungibleTokenAttributes
+        Owner Predicate: ${this.ownerPredicate.toString()}
+        Type ID: ${this.typeId.toString()}
+        Name: ${this.name}
+        URI: ${this.uri}
+        Data: ${this.data.toString()}
+        Data Update Predicate: ${this.dataUpdatePredicate.toString()}
+        Token Creation Predicate Signatures: [
+          ${this.tokenCreationPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/CreateNonFungibleTokenPayload.ts
+++ b/src/transaction/CreateNonFungibleTokenPayload.ts
@@ -1,8 +1,8 @@
-import { CreateNonFungibleTokenAttributes } from './CreateNonFungibleTokenAttributes.js';
-import { TransactionPayload } from './TransactionPayload.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
 import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { CreateNonFungibleTokenAttributes } from './CreateNonFungibleTokenAttributes.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class CreateNonFungibleTokenPayload extends TransactionPayload<CreateNonFungibleTokenAttributes> {
   public static readonly PAYLOAD_TYPE = 'createNToken';

--- a/src/transaction/CreateNonFungibleTokenTypeAttributes.ts
+++ b/src/transaction/CreateNonFungibleTokenTypeAttributes.ts
@@ -1,7 +1,21 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { TokenIcon } from './TokenIcon.js';
-import { IPredicate } from './IPredicate.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TokenIcon, TokenIconArray } from './TokenIcon.js';
+
+export type CreateNonFungibleTokenTypeAttributesArray = readonly [
+  string,
+  string,
+  TokenIconArray,
+  Uint8Array | null,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array[] | null,
+];
 
 export class CreateNonFungibleTokenTypeAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -16,11 +30,11 @@ export class CreateNonFungibleTokenTypeAttributes implements ITransactionPayload
     public readonly subTypeCreationPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): CreateNonFungibleTokenTypeAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): CreateNonFungibleTokenTypeAttributesArray {
     return [
       this.symbol,
       this.name,
@@ -32,5 +46,21 @@ export class CreateNonFungibleTokenTypeAttributes implements ITransactionPayload
       this.dataUpdatePredicate.getBytes(),
       this.subTypeCreationPredicateSignatures,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      CreateNonFungibleTokenTypeAttributes
+        Symbol: ${this.symbol}
+        Name: ${this.name}
+        Icon: ${this.icon.toString()}
+        Parent Type ID: ${this.parentTypeId?.toString() ?? 'null'}
+        Sub Type Creation Predicate: ${this.subTypeCreationPredicate.toString()}
+        Token Creation Predicate: ${this.tokenCreationPredicate.toString()}
+        Invariant Predicate: ${this.invariantPredicate.toString()}
+        Data Update Predicate: ${this.dataUpdatePredicate.toString()}
+        Sub Type Creation Predicate Signatures: [
+          ${this.subTypeCreationPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/CreateNonFungibleTokenTypePayload.ts
+++ b/src/transaction/CreateNonFungibleTokenTypePayload.ts
@@ -1,8 +1,8 @@
-import { CreateNonFungibleTokenTypeAttributes } from './CreateNonFungibleTokenTypeAttributes.js';
-import { TransactionPayload } from './TransactionPayload.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
 import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { CreateNonFungibleTokenTypeAttributes } from './CreateNonFungibleTokenTypeAttributes.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class CreateNonFungibleTokenTypePayload extends TransactionPayload<CreateNonFungibleTokenTypeAttributes> {
   public static readonly PAYLOAD_TYPE = 'createNType';

--- a/src/transaction/FeeCreditPayload.ts
+++ b/src/transaction/FeeCreditPayload.ts
@@ -1,8 +1,8 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { TransactionPayload } from './TransactionPayload.js';
+import { IUnitId } from '../IUnitId.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
 import { FeeCreditClientMetadata } from './FeeCreditClientMetadata.js';
-import { IUnitId } from '../IUnitId.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class FeeCreditPayload<T extends ITransactionPayloadAttributes> extends TransactionPayload<T> {
   protected constructor(

--- a/src/transaction/FeeCreditUnitId.ts
+++ b/src/transaction/FeeCreditUnitId.ts
@@ -1,5 +1,5 @@
-import { UnitIdWithType } from './UnitIdWithType.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
+import { UnitIdWithType } from './UnitIdWithType.js';
 import { UnitType } from './UnitType.js';
 
 type FeeCreditRecordPartition = SystemIdentifier.MONEY_PARTITION | SystemIdentifier.TOKEN_PARTITION;

--- a/src/transaction/LockBillAttributes.ts
+++ b/src/transaction/LockBillAttributes.ts
@@ -1,4 +1,8 @@
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
 import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type LockBillAttributesArray = readonly [bigint, Uint8Array];
 
 export class LockBillAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -6,11 +10,18 @@ export class LockBillAttributes implements ITransactionPayloadAttributes {
     public readonly backlink: Uint8Array,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): LockBillAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): LockBillAttributesArray {
     return [this.lockStatus, this.backlink];
+  }
+
+  public toString(): string {
+    return dedent`
+      LockBillAttributes
+        Lock Status: ${this.lockStatus}
+        Backlink: ${Base16Converter.encode(this.backlink)}`;
   }
 }

--- a/src/transaction/LockBillPayload.ts
+++ b/src/transaction/LockBillPayload.ts
@@ -1,8 +1,8 @@
-import { SystemIdentifier } from '../SystemIdentifier.js';
 import { IUnitId } from '../IUnitId.js';
-import { TransactionPayload } from './TransactionPayload.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { LockBillAttributes } from './LockBillAttributes.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class LockBillPayload extends TransactionPayload<LockBillAttributes> {
   public static readonly PAYLOAD_TYPE = 'lock';

--- a/src/transaction/NonFungibleTokenData.ts
+++ b/src/transaction/NonFungibleTokenData.ts
@@ -1,5 +1,7 @@
-import { INonFungibleTokenData } from './INonFungibleTokenData.js';
 import { ICborCodec } from '../codec/cbor/ICborCodec.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { INonFungibleTokenData } from './INonFungibleTokenData.js';
 
 export class NonFungibleTokenData implements INonFungibleTokenData {
   private constructor(private readonly data: Uint8Array) {}
@@ -8,11 +10,19 @@ export class NonFungibleTokenData implements INonFungibleTokenData {
     return new NonFungibleTokenData(await cborCodec.encode(data));
   }
 
+  public static CreateFromBytes(data: Uint8Array): NonFungibleTokenData {
+    return new NonFungibleTokenData(data);
+  }
+
   public static async Parse(cborCodec: ICborCodec, data: Uint8Array): Promise<unknown> {
     return cborCodec.decode(data);
   }
 
   public getBytes(): Uint8Array {
     return new Uint8Array(this.data);
+  }
+
+  public toString(): string {
+    return dedent`${Base16Converter.encode(this.data)}`;
   }
 }

--- a/src/transaction/PayToPublicKeyHashPredicate.ts
+++ b/src/transaction/PayToPublicKeyHashPredicate.ts
@@ -1,6 +1,7 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { IPredicate } from './IPredicate.js';
 import { ICborCodec } from '../codec/cbor/ICborCodec.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { IPredicate } from './IPredicate.js';
 
 export class PayToPublicKeyHashPredicate implements IPredicate {
   private static readonly P2pkh256ID = 0x02;
@@ -15,5 +16,9 @@ export class PayToPublicKeyHashPredicate implements IPredicate {
     return new PayToPublicKeyHashPredicate(
       await cborCodec.encode([0x00, new Uint8Array([PayToPublicKeyHashPredicate.P2pkh256ID]), sha256(publicKey)]),
     );
+  }
+
+  public toString(): string {
+    return `PayToPublicKeyHashPredicate[${Base16Converter.encode(this.bytes)}]`;
   }
 }

--- a/src/transaction/ReclaimFeeCreditAttributes.ts
+++ b/src/transaction/ReclaimFeeCreditAttributes.ts
@@ -1,0 +1,32 @@
+import dedent from 'dedent';
+import { TransactionProofArray } from '../TransactionProof.js';
+import { TransactionRecordArray } from '../TransactionRecord.js';
+import { TransactionRecordWithProof } from '../TransactionRecordWithProof.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { CloseFeeCreditPayload } from './CloseFeeCreditPayload.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type ReclaimFeeCreditAttributesArray = [TransactionRecordArray, TransactionProofArray, Uint8Array];
+
+export class ReclaimFeeCreditAttributes implements ITransactionPayloadAttributes {
+  public constructor(
+    public readonly proof: TransactionRecordWithProof<CloseFeeCreditPayload>,
+    public readonly backlink: Uint8Array,
+  ) {}
+
+  public toOwnerProofData(): ReclaimFeeCreditAttributesArray {
+    return this.toArray();
+  }
+
+  public toArray(): ReclaimFeeCreditAttributesArray {
+    return [this.proof.transactionRecord.toArray(), this.proof.transactionProof.toArray(), this.backlink];
+  }
+
+  public toString(): string {
+    return dedent`
+      ReclaimFeeCreditAttributes
+          ${this.proof.toString()}
+          Backlink: ${Base16Converter.encode(this.backlink)}
+      `;
+  }
+}

--- a/src/transaction/ReclaimFeeCreditPayload.ts
+++ b/src/transaction/ReclaimFeeCreditPayload.ts
@@ -1,0 +1,13 @@
+import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { FeeCreditClientMetadata } from './FeeCreditClientMetadata.js';
+import { FeeCreditPayload } from './FeeCreditPayload.js';
+import { ReclaimFeeCreditAttributes } from './ReclaimFeeCreditAttributes.js';
+
+export class ReclaimFeeCreditPayload extends FeeCreditPayload<ReclaimFeeCreditAttributes> {
+  public static readonly PAYLOAD_TYPE = 'reclFC';
+
+  public constructor(attributes: ReclaimFeeCreditAttributes, unitId: IUnitId, clientMetadata: FeeCreditClientMetadata) {
+    super(ReclaimFeeCreditPayload.PAYLOAD_TYPE, SystemIdentifier.MONEY_PARTITION, unitId, attributes, clientMetadata);
+  }
+}

--- a/src/transaction/SplitBillAttributes.ts
+++ b/src/transaction/SplitBillAttributes.ts
@@ -1,5 +1,9 @@
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
 import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { SplitBillUnit } from './SplitBillUnit.js';
+import { SplitBillUnit, SplitBillUnitArray } from './SplitBillUnit.js';
+
+export type SplitBillAttributesArray = [SplitBillUnitArray[], bigint, Uint8Array];
 
 export class SplitBillAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -8,11 +12,21 @@ export class SplitBillAttributes implements ITransactionPayloadAttributes {
     public readonly backlink: Uint8Array,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): SplitBillAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): SplitBillAttributesArray {
     return [this.targetUnits.map((unit) => unit.toArray()), this.remainingBillValue, this.backlink];
+  }
+
+  public toString(): string {
+    return dedent`
+      SplitBillAttributes
+          Target Units: [
+            ${this.targetUnits.map((unit) => unit.toString()).join('\n')}
+          ]
+          Remaining Bill Value: ${this.remainingBillValue}
+          Backlink: ${Base16Converter.encode(this.backlink)}`;
   }
 }

--- a/src/transaction/SplitBillPayload.ts
+++ b/src/transaction/SplitBillPayload.ts
@@ -1,8 +1,8 @@
-import { TransactionPayload } from './TransactionPayload.js';
 import { IUnitId } from '../IUnitId.js';
-import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
+import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SplitBillAttributes } from './SplitBillAttributes.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class SplitBillPayload extends TransactionPayload<SplitBillAttributes> {
   public static readonly PAYLOAD_TYPE = 'split';

--- a/src/transaction/SplitBillUnit.ts
+++ b/src/transaction/SplitBillUnit.ts
@@ -1,4 +1,7 @@
+import { dedent } from '../util/StringUtils.js';
 import { IPredicate } from './IPredicate.js';
+
+export type SplitBillUnitArray = readonly [bigint, Uint8Array];
 
 export class SplitBillUnit {
   public constructor(
@@ -6,7 +9,14 @@ export class SplitBillUnit {
     public readonly ownerPredicate: IPredicate,
   ) {}
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): SplitBillUnitArray {
     return [this.value, this.ownerPredicate.getBytes()];
+  }
+
+  public toString(): string {
+    return dedent`
+      SplitBillUnit
+        Value: ${this.value}
+        Owner Predicate: ${this.ownerPredicate.toString()}`;
   }
 }

--- a/src/transaction/SplitFungibleTokenAttributes.ts
+++ b/src/transaction/SplitFungibleTokenAttributes.ts
@@ -1,6 +1,18 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { IPredicate } from './IPredicate.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type SplitFungibleTokenAttributesArray = readonly [
+  Uint8Array,
+  bigint,
+  Uint8Array | null,
+  Uint8Array,
+  Uint8Array,
+  bigint,
+  Uint8Array[] | null,
+];
 
 export class SplitFungibleTokenAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -13,7 +25,7 @@ export class SplitFungibleTokenAttributes implements ITransactionPayloadAttribut
     public readonly invariantPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): SplitFungibleTokenAttributesArray {
     return [
       this.ownerPredicate.getBytes(),
       this.targetValue,
@@ -25,7 +37,7 @@ export class SplitFungibleTokenAttributes implements ITransactionPayloadAttribut
     ];
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): SplitFungibleTokenAttributesArray {
     return [
       this.ownerPredicate.getBytes(),
       this.targetValue,
@@ -35,5 +47,19 @@ export class SplitFungibleTokenAttributes implements ITransactionPayloadAttribut
       this.remainingValue,
       this.invariantPredicateSignatures,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      SplitFungibleTokenAttributes
+        Owner Predicate: ${this.ownerPredicate.toString()}
+        Target Value: ${this.targetValue}
+        Nonce: ${this.nonce ? Base16Converter.encode(this.nonce) : 'null'}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Type ID: ${this.typeId.toString()}
+        Remaining Value: ${this.remainingValue}
+        Invariant Predicate Signatures: [
+          ${this.invariantPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/SplitFungibleTokenPayload.ts
+++ b/src/transaction/SplitFungibleTokenPayload.ts
@@ -1,8 +1,8 @@
-import { TransactionPayload } from './TransactionPayload.js';
 import { IUnitId } from '../IUnitId.js';
-import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
+import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SplitFungibleTokenAttributes } from './SplitFungibleTokenAttributes.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class SplitFungibleTokenPayload extends TransactionPayload<SplitFungibleTokenAttributes> {
   public static readonly PAYLOAD_TYPE = 'splitFToken';

--- a/src/transaction/SwapBillsWithDustCollectorAttributes.ts
+++ b/src/transaction/SwapBillsWithDustCollectorAttributes.ts
@@ -1,24 +1,46 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TransactionProofArray } from '../TransactionProof.js';
+import { TransactionRecordArray } from '../TransactionRecord.js';
+import { TransactionRecordWithProof } from '../TransactionRecordWithProof.js';
+import { dedent } from '../util/StringUtils.js';
 import { IPredicate } from './IPredicate.js';
-import { TransactionProof } from '../TransactionProof.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TransferBillToDustCollectorPayload } from './TransferBillDustCollectorPayload.js';
+
+export type SwapBillsWithDustCollectorAttributesArray = readonly [
+  Uint8Array,
+  TransactionRecordArray[],
+  TransactionProofArray[],
+  bigint,
+];
 
 export class SwapBillsWithDustCollectorAttributes implements ITransactionPayloadAttributes {
   public constructor(
     public readonly ownerPredicate: IPredicate,
-    public readonly proofs: ReadonlyArray<TransactionProof>,
+    public readonly proofs: ReadonlyArray<TransactionRecordWithProof<TransferBillToDustCollectorPayload>>,
     public readonly targetValue: bigint,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): SwapBillsWithDustCollectorAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): SwapBillsWithDustCollectorAttributesArray {
     return [
       this.ownerPredicate.getBytes(),
-      this.proofs.map((proof) => proof.transactionRecord),
-      this.proofs.map((proof) => proof.transactionProof),
+      this.proofs.map((proof) => proof.transactionRecord.toArray()),
+      this.proofs.map((proof) => proof.transactionProof.toArray()),
       this.targetValue,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      SwapBillsWithDustCollectorAttributes
+          Owner Predicate: ${this.ownerPredicate.toString()}
+          Proofs: [
+            ${this.proofs.map((proof) => proof.toString()).join('\n')}
+          ]
+          Target Value: ${this.targetValue}
+      `;
   }
 }

--- a/src/transaction/SwapBillsWithDustCollectorPayload.ts
+++ b/src/transaction/SwapBillsWithDustCollectorPayload.ts
@@ -1,8 +1,8 @@
-import { TransactionPayload } from './TransactionPayload.js';
 import { IUnitId } from '../IUnitId.js';
-import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
+import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SwapBillsWithDustCollectorAttributes } from './SwapBillsWithDustCollectorAttributes.js';
+import { TransactionPayload } from './TransactionPayload.js';
 
 export class SwapBillsWithDustCollectorPayload extends TransactionPayload<SwapBillsWithDustCollectorAttributes> {
   public static readonly PAYLOAD_TYPE = 'swapDC';

--- a/src/transaction/TokenIcon.ts
+++ b/src/transaction/TokenIcon.ts
@@ -1,10 +1,18 @@
+import { Base16Converter } from '../util/Base16Converter.js';
+
+export type TokenIconArray = readonly [string, Uint8Array];
+
 export class TokenIcon {
   public constructor(
     public readonly type: string,
     public readonly data: Uint8Array,
   ) {}
 
-  public toArray(): unknown[] {
+  public toArray(): TokenIconArray {
     return [this.type, this.data];
+  }
+
+  public toString(): string {
+    return `TokenIcon: ${this.type}; ${Base16Converter.encode(this.data)}`;
   }
 }

--- a/src/transaction/TransactionOrder.ts
+++ b/src/transaction/TransactionOrder.ts
@@ -1,19 +1,30 @@
-import { TransactionPayload } from './TransactionPayload.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
 import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { TransactionPayload, TransactionPayloadArray } from './TransactionPayload.js';
 
+export type TransactionOrderArray = readonly [TransactionPayloadArray, Uint8Array, Uint8Array | null];
 export class TransactionOrder<T extends TransactionPayload<ITransactionPayloadAttributes>> {
   public constructor(
     public readonly payload: T,
     public readonly ownerProof: Uint8Array,
-    public readonly feeProof: Uint8Array,
-    public readonly bytes: Uint8Array,
+    public readonly feeProof: Uint8Array | null,
+    private readonly bytes: Uint8Array,
   ) {}
 
   public getBytes(): Uint8Array {
     return new Uint8Array(this.bytes);
   }
 
-  public values(): unknown[] {
+  public toArray(): TransactionOrderArray {
     return [this.payload.toArray(), this.ownerProof, this.feeProof];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransactionOrder
+        ${this.payload.toString()}
+        Owner Proof: ${Base16Converter.encode(this.ownerProof)}
+        Fee Proof: ${this.feeProof ? Base16Converter.encode(this.feeProof) : null}`;
   }
 }

--- a/src/transaction/TransferBillAttributes.ts
+++ b/src/transaction/TransferBillAttributes.ts
@@ -1,5 +1,9 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
 import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type TransferBillAttributesArray = [Uint8Array, bigint, Uint8Array];
 
 export class TransferBillAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -8,11 +12,19 @@ export class TransferBillAttributes implements ITransactionPayloadAttributes {
     public readonly backlink: Uint8Array,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): TransferBillAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
-    return [this.ownerPredicate.getBytes(), this.targetValue, this.backlink];
+  public toArray(): TransferBillAttributesArray {
+    return [new Uint8Array(this.ownerPredicate.getBytes()), this.targetValue, this.backlink];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransferBillAttributes
+        Owner Predicate: ${this.ownerPredicate.toString()}
+        Target Value: ${this.targetValue}
+        Backlink: ${Base16Converter.encode(this.backlink)}`;
   }
 }

--- a/src/transaction/TransferBillDustCollectorPayload.ts
+++ b/src/transaction/TransferBillDustCollectorPayload.ts
@@ -1,7 +1,7 @@
-import { TransactionPayload } from './TransactionPayload.js';
 import { IUnitId } from '../IUnitId.js';
-import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
+import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
 import { TransferBillToDustCollectorAttributes } from './TransferBillToDustCollectorAttributes.js';
 
 export class TransferBillToDustCollectorPayload extends TransactionPayload<TransferBillToDustCollectorAttributes> {

--- a/src/transaction/TransferBillPayload.ts
+++ b/src/transaction/TransferBillPayload.ts
@@ -1,8 +1,8 @@
+import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { TransactionPayload } from './TransactionPayload.js';
 import { TransferBillAttributes } from './TransferBillAttributes.js';
-import { IUnitId } from '../IUnitId.js';
-import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
 
 export class TransferBillPayload extends TransactionPayload<TransferBillAttributes> {
   public static readonly PAYLOAD_TYPE = 'trans';

--- a/src/transaction/TransferBillToDustCollectorAttributes.ts
+++ b/src/transaction/TransferBillToDustCollectorAttributes.ts
@@ -1,5 +1,9 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type TransferBillToDustCollectorAttributesArray = readonly [bigint, Uint8Array, Uint8Array, Uint8Array];
 
 export class TransferBillToDustCollectorAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -9,11 +13,20 @@ export class TransferBillToDustCollectorAttributes implements ITransactionPayloa
     public readonly backlink: Uint8Array,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): TransferBillToDustCollectorAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): TransferBillToDustCollectorAttributesArray {
     return [this.value, this.targetUnitId.getBytes(), this.targetUnitBacklink, this.backlink];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransferBillToDustCollectorAttributes
+        Value: ${this.value}
+        Target Unit ID: ${this.targetUnitId.toString()}
+        Target Unit Backlink: ${Base16Converter.encode(this.targetUnitBacklink)}
+        Backlink: ${Base16Converter.encode(this.backlink)}`;
   }
 }

--- a/src/transaction/TransferFeeCreditAttributes.ts
+++ b/src/transaction/TransferFeeCreditAttributes.ts
@@ -1,6 +1,18 @@
 import { SystemIdentifier } from '../SystemIdentifier.js';
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
 import { FeeCreditUnitId } from './FeeCreditUnitId.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type TransferFeeCreditAttributesArray = readonly [
+  bigint,
+  SystemIdentifier,
+  Uint8Array,
+  bigint,
+  bigint,
+  Uint8Array | null,
+  Uint8Array,
+];
 
 export class TransferFeeCreditAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -13,11 +25,11 @@ export class TransferFeeCreditAttributes implements ITransactionPayloadAttribute
     public readonly backlink: Uint8Array,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): TransferFeeCreditAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): TransferFeeCreditAttributesArray {
     return [
       this.amount,
       this.targetSystemIdentifier,
@@ -27,5 +39,19 @@ export class TransferFeeCreditAttributes implements ITransactionPayloadAttribute
       this.targetUnitBacklink,
       this.backlink,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransferFeeCreditAttributes
+        Amount: ${this.amount}
+        Target System Identifier: ${this.targetSystemIdentifier.toString()}
+        Target Unit ID: ${this.targetUnitId.toString()}
+        Earliest Addition Time: ${this.earliestAdditionTime}
+        Latest Addition Time: ${this.latestAdditionTime}
+        Target Unit Backlink: ${
+          this.targetUnitBacklink === null ? 'null' : Base16Converter.encode(this.targetUnitBacklink)
+        }
+        Backlink: ${Base16Converter.encode(this.backlink)}`;
   }
 }

--- a/src/transaction/TransferFeeCreditPayload.ts
+++ b/src/transaction/TransferFeeCreditPayload.ts
@@ -1,8 +1,8 @@
-import { FeeCreditPayload } from './FeeCreditPayload.js';
-import { TransferFeeCreditAttributes } from './TransferFeeCreditAttributes.js';
+import { IUnitId } from '../IUnitId.js';
 import { SystemIdentifier } from '../SystemIdentifier.js';
 import { FeeCreditClientMetadata } from './FeeCreditClientMetadata.js';
-import { IUnitId } from '../IUnitId.js';
+import { FeeCreditPayload } from './FeeCreditPayload.js';
+import { TransferFeeCreditAttributes } from './TransferFeeCreditAttributes.js';
 
 export class TransferFeeCreditPayload extends FeeCreditPayload<TransferFeeCreditAttributes> {
   public static readonly PAYLOAD_TYPE = 'transFC';

--- a/src/transaction/TransferFungibleTokenAttributes.ts
+++ b/src/transaction/TransferFungibleTokenAttributes.ts
@@ -1,6 +1,17 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { IPredicate } from './IPredicate.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type TransferFungibleTokenAttributesArray = readonly [
+  Uint8Array,
+  bigint,
+  bigint,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array[] | null,
+];
 
 export class TransferFungibleTokenAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -12,11 +23,11 @@ export class TransferFungibleTokenAttributes implements ITransactionPayloadAttri
     public readonly invariantPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): TransferFungibleTokenAttributesArray {
     return [this.ownerPredicate.getBytes(), this.value, this.nonce, this.backlink, this.typeId.getBytes(), null];
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): TransferFungibleTokenAttributesArray {
     return [
       this.ownerPredicate.getBytes(),
       this.value,
@@ -25,5 +36,18 @@ export class TransferFungibleTokenAttributes implements ITransactionPayloadAttri
       this.typeId.getBytes(),
       this.invariantPredicateSignatures,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransferFungibleTokenAttributes
+        Owner Predicate: ${this.ownerPredicate.toString()}
+        Value: ${this.value}
+        Nonce: ${this.nonce}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Type ID: ${this.typeId.toString()}
+        Invariant Predicate Signatures: [
+          ${this.invariantPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/TransferFungibleTokenPayload.ts
+++ b/src/transaction/TransferFungibleTokenPayload.ts
@@ -1,8 +1,8 @@
-import { TransactionPayload } from './TransactionPayload.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
-import { TransferFungibleTokenAttributes } from './TransferFungibleTokenAttributes.js';
 import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
+import { TransferFungibleTokenAttributes } from './TransferFungibleTokenAttributes.js';
 
 export class TransferFungibleTokenPayload extends TransactionPayload<TransferFungibleTokenAttributes> {
   public static readonly PAYLOAD_TYPE = 'transFToken';

--- a/src/transaction/TransferNonFungibleTokenAttributes.ts
+++ b/src/transaction/TransferNonFungibleTokenAttributes.ts
@@ -1,6 +1,16 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
-import { IPredicate } from './IPredicate.js';
 import { IUnitId } from '../IUnitId.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
+import { IPredicate } from './IPredicate.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type TransferNonFungibleTokenAttributesArray = readonly [
+  Uint8Array,
+  Uint8Array | null,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array[] | null,
+];
 
 export class TransferNonFungibleTokenAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -11,11 +21,11 @@ export class TransferNonFungibleTokenAttributes implements ITransactionPayloadAt
     public readonly invariantPredicateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): TransferNonFungibleTokenAttributesArray {
     return [this.ownerPredicate.getBytes(), this.nonce, this.backlink, this.typeId.getBytes(), null];
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): TransferNonFungibleTokenAttributesArray {
     return [
       this.ownerPredicate.getBytes(),
       this.nonce,
@@ -23,5 +33,17 @@ export class TransferNonFungibleTokenAttributes implements ITransactionPayloadAt
       this.typeId.getBytes(),
       this.invariantPredicateSignatures,
     ];
+  }
+
+  public toString(): string {
+    return dedent`
+      TransferNonFungibleTokenAttributes
+        Owner Predicate: ${this.ownerPredicate.toString()}
+        Nonce: ${this.nonce ? Base16Converter.encode(this.nonce) : 'null'}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Type ID: ${this.typeId.toString()}
+        Invariant Predicate Signatures: [
+          ${this.invariantPredicateSignatures?.map((signature) => Base16Converter.encode(signature)).join(',\n') ?? 'null'}
+        ]`;
   }
 }

--- a/src/transaction/TransferNonFungibleTokenPayload.ts
+++ b/src/transaction/TransferNonFungibleTokenPayload.ts
@@ -1,8 +1,8 @@
-import { TransactionPayload } from './TransactionPayload.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
-import { TransferNonFungibleTokenAttributes } from './TransferNonFungibleTokenAttributes.js';
 import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
+import { TransactionPayload } from './TransactionPayload.js';
+import { TransferNonFungibleTokenAttributes } from './TransferNonFungibleTokenAttributes.js';
 
 export class TransferNonFungibleTokenPayload extends TransactionPayload<TransferNonFungibleTokenAttributes> {
   public static readonly PAYLOAD_TYPE = 'transNToken';

--- a/src/transaction/UnitIdWithType.ts
+++ b/src/transaction/UnitIdWithType.ts
@@ -1,5 +1,5 @@
-import { UnitType } from './UnitType.js';
 import { UnitId } from '../UnitId.js';
+import { UnitType } from './UnitType.js';
 
 export class UnitIdWithType extends UnitId {
   public constructor(identifier: Uint8Array, type: UnitType) {

--- a/src/transaction/UnlockBillAttributes.ts
+++ b/src/transaction/UnlockBillAttributes.ts
@@ -1,13 +1,23 @@
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
 import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type UnlockBillAttributesArray = readonly [Uint8Array];
 
 export class UnlockBillAttributes implements ITransactionPayloadAttributes {
   public constructor(public readonly backlink: Uint8Array) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): UnlockBillAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): UnlockBillAttributesArray {
     return [this.backlink];
+  }
+
+  public toString(): string {
+    return dedent`
+      UnlockBillAttributes
+        Backlink: ${Base16Converter.encode(this.backlink)}`;
   }
 }

--- a/src/transaction/UnlockBillPayload.ts
+++ b/src/transaction/UnlockBillPayload.ts
@@ -1,14 +1,13 @@
-import { SystemIdentifier } from '../SystemIdentifier.js';
 import { IUnitId } from '../IUnitId.js';
-import { TransactionPayload } from './TransactionPayload.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
 import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
-import { LockBillAttributes } from './LockBillAttributes.js';
+import { TransactionPayload } from './TransactionPayload.js';
 import { UnlockBillAttributes } from './UnlockBillAttributes.js';
 
 export class UnlockBillPayload extends TransactionPayload<UnlockBillAttributes> {
   public static readonly PAYLOAD_TYPE = 'unlock';
 
-  public constructor(attributes: LockBillAttributes, unitId: IUnitId, clientMetadata: ITransactionClientMetadata) {
+  public constructor(attributes: UnlockBillAttributes, unitId: IUnitId, clientMetadata: ITransactionClientMetadata) {
     super(UnlockBillPayload.PAYLOAD_TYPE, SystemIdentifier.MONEY_PARTITION, unitId, attributes, clientMetadata);
   }
 }

--- a/src/transaction/UpdateNonFungibleTokenAttributes.ts
+++ b/src/transaction/UpdateNonFungibleTokenAttributes.ts
@@ -1,5 +1,9 @@
-import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+import { Base16Converter } from '../util/Base16Converter.js';
+import { dedent } from '../util/StringUtils.js';
 import { INonFungibleTokenData } from './INonFungibleTokenData.js';
+import { ITransactionPayloadAttributes } from './ITransactionPayloadAttributes.js';
+
+export type UpdateNonFungibleTokenAttributesArray = readonly [Uint8Array, Uint8Array, Uint8Array[] | null];
 
 export class UpdateNonFungibleTokenAttributes implements ITransactionPayloadAttributes {
   public constructor(
@@ -8,11 +12,19 @@ export class UpdateNonFungibleTokenAttributes implements ITransactionPayloadAttr
     public readonly dataUpdateSignatures: Uint8Array[] | null,
   ) {}
 
-  public toOwnerProofData(): ReadonlyArray<unknown> {
+  public toOwnerProofData(): UpdateNonFungibleTokenAttributesArray {
     return this.toArray();
   }
 
-  public toArray(): ReadonlyArray<unknown> {
+  public toArray(): UpdateNonFungibleTokenAttributesArray {
     return [this.data.getBytes(), this.backlink, this.dataUpdateSignatures];
+  }
+
+  public toString(): string {
+    return dedent`
+      UpdateNonFungibleTokenAttributes
+        Data: ${this.data.toString()}
+        Backlink: ${Base16Converter.encode(this.backlink)}
+        Data Update Signatures: ${this.dataUpdateSignatures?.map((signature) => Base16Converter.encode(signature))}`;
   }
 }

--- a/src/transaction/UpdateNonFungibleTokenPayload.ts
+++ b/src/transaction/UpdateNonFungibleTokenPayload.ts
@@ -1,8 +1,8 @@
+import { IUnitId } from '../IUnitId.js';
+import { SystemIdentifier } from '../SystemIdentifier.js';
+import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
 import { TransactionPayload } from './TransactionPayload.js';
 import { UpdateNonFungibleTokenAttributes } from './UpdateNonFungibleTokenAttributes.js';
-import { IUnitId } from '../IUnitId.js';
-import { ITransactionClientMetadata } from './ITransactionClientMetadata.js';
-import { SystemIdentifier } from '../SystemIdentifier.js';
 
 export class UpdateNonFungibleTokenPayload extends TransactionPayload<UpdateNonFungibleTokenAttributes> {
   public static readonly PAYLOAD_TYPE = 'updateNToken';

--- a/src/util/Base16Converter.ts
+++ b/src/util/Base16Converter.ts
@@ -47,11 +47,17 @@ export class Base16Converter {
     const result = [];
     for (let i = hex.startsWith('0X', 0) ? 2 : 0; i < hex.length; i += 2) {
       if (
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
         typeof Base16Converter.HEX_BYTE_MAP[hex[i]] === 'undefined' ||
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
         typeof Base16Converter.HEX_BYTE_MAP[hex[i + 1]] === 'undefined'
       ) {
         throw new Error('Invalid HEX');
       }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
       result.push((Base16Converter.HEX_BYTE_MAP[hex[i]] << 4) + Base16Converter.HEX_BYTE_MAP[hex[i + 1]]);
     }
 

--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -1,0 +1,34 @@
+/**
+ * String dedent function, calculates distance which has to be removed from second line string
+ */
+export function dedent(strings: TemplateStringsArray, ...data: unknown[]): string {
+  if (strings.length === 0) {
+    return '';
+  }
+
+  let rows = strings[0].split('\n');
+  if (rows.shift()?.length !== 0) {
+    throw new Error('First line must be empty');
+  }
+
+  const whiteSpacesFromEdge = rows[0].length - rows[0].trimStart().length;
+  const result: string[] = [];
+  for (let j = 0; j < strings.length; j++) {
+    result.push(`${result.pop() || ''}${rows[0].slice(whiteSpacesFromEdge)}`);
+    for (let i = 1; i < rows.length; i++) {
+      result.push(rows[i].slice(whiteSpacesFromEdge));
+    }
+
+    const lastElement = result.pop();
+    const whiteSpaces = lastElement!.length - lastElement!.trimStart().length;
+    const dataRows = j < data.length ? String(data[j]).split('\n') : [''];
+    result.push(`${lastElement}${dataRows[0]}`);
+    for (let i = 1; i < dataRows.length; i++) {
+      result.push(`${' '.repeat(whiteSpaces)}${dataRows[i]}`);
+    }
+
+    rows = j + 1 < strings.length ? strings[j + 1].split('\n') : [];
+  }
+
+  return result.join('\n');
+}

--- a/tests/codec/cbor/CborCodecTest.ts
+++ b/tests/codec/cbor/CborCodecTest.ts
@@ -5,7 +5,7 @@ describe('Node Codec test - Valid input', () => {
   it('Decodes and encodes successfully', async () => {
     const base64Cbor = 'g4UAZXRyYW5zQQGDRIMAAfYB9oMAAPZBAfY=';
     const cborCodecNode: ICborCodec = new CborCodecNode();
-    const parsed = await cborCodecNode.decode(Buffer.from(base64Cbor, 'base64'));
+    const parsed = (await cborCodecNode.decode(Buffer.from(base64Cbor, 'base64'))) as [[unknown, string]];
     expect(parsed[0][1]).toEqual('trans');
     const uint8Array = await cborCodecNode.encode(parsed);
     expect(Buffer.from(uint8Array).toString('base64')).toEqual(base64Cbor);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,10 @@
     "target": "es2020",
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Add toString methods to transaction payloads and data for pretty format. Add strict typescript check
Add eslint for example folder
Add import linter
Create transaction proof factory for building proper transaction proof object Add getBlock method back to state api client.
Parse most of the stateproof for getUnit
Make cbor codec to use Uint8Array instead of nodejs buffer.