### PR TITLE
Cleanup

### DIFF
--- a/src/fees/attributes/SetFeeCreditAttributes.ts
+++ b/src/fees/attributes/SetFeeCreditAttributes.ts
@@ -23,7 +23,7 @@ export class SetFeeCreditAttributes implements ITransactionPayloadAttributes {
     public readonly counter: bigint | null,
   ) {
     this.amount = BigInt(this.amount);
-    this.counter = this.counter ?? null;
+    this.counter = this.counter != null ? BigInt(this.counter) : null;
   }
 
   /**
@@ -59,7 +59,7 @@ export class SetFeeCreditAttributes implements ITransactionPayloadAttributes {
     return CborEncoder.encodeArray([
       CborEncoder.encodeByteString(this.ownerPredicate.bytes),
       CborEncoder.encodeUnsignedInteger(this.amount),
-      this.counter ? CborEncoder.encodeUnsignedInteger(this.counter) : CborEncoder.encodeNull(),
+      this.counter != null ? CborEncoder.encodeUnsignedInteger(this.counter) : CborEncoder.encodeNull(),
     ]);
   }
 }

--- a/src/fees/attributes/TransferFeeCreditAttributes.ts
+++ b/src/fees/attributes/TransferFeeCreditAttributes.ts
@@ -30,7 +30,7 @@ export class TransferFeeCreditAttributes implements ITransactionPayloadAttribute
   ) {
     this.amount = BigInt(this.amount);
     this.latestAdditionTime = BigInt(this.latestAdditionTime);
-    this.targetUnitCounter = this.targetUnitCounter ? BigInt(this.targetUnitCounter) : null;
+    this.targetUnitCounter = this.targetUnitCounter != null ? BigInt(this.targetUnitCounter) : null;
     this.counter = BigInt(this.counter);
   }
 
@@ -75,7 +75,9 @@ export class TransferFeeCreditAttributes implements ITransactionPayloadAttribute
       CborEncoder.encodeUnsignedInteger(this.targetPartitionIdentifier),
       CborEncoder.encodeByteString(this.targetUnitId.bytes),
       CborEncoder.encodeUnsignedInteger(this.latestAdditionTime),
-      this.targetUnitCounter ? CborEncoder.encodeUnsignedInteger(this.targetUnitCounter) : CborEncoder.encodeNull(),
+      this.targetUnitCounter != null
+        ? CborEncoder.encodeUnsignedInteger(this.targetUnitCounter)
+        : CborEncoder.encodeNull(),
       CborEncoder.encodeUnsignedInteger(this.counter),
     ]);
   }

--- a/src/fees/transactions/TransferFeeCredit.ts
+++ b/src/fees/transactions/TransferFeeCredit.ts
@@ -56,7 +56,7 @@ export class TransferFeeCredit {
           data.targetPartitionIdentifier,
           feeCreditRecordId,
           data.latestAdditionTime,
-          data.feeCreditRecord?.counter ?? 0n,
+          data.feeCreditRecord?.counter ?? null,
           data.bill.counter,
         ),
         data.stateLock,

--- a/src/tokens/transactions/BurnFungibleToken.ts
+++ b/src/tokens/transactions/BurnFungibleToken.ts
@@ -12,8 +12,7 @@ import { TokenPartitionTransactionType } from '../TokenPartitionTransactionType.
 
 export type BurnFungibleTokenTransactionOrder = TransactionOrder<BurnFungibleTokenAttributes, TypeOwnerProofsAuthProof>;
 interface IBurnFungibleTokenTransactionData extends ITransactionData {
-  type: { unitId: IUnitId };
-  token: { unitId: IUnitId; counter: bigint; value: bigint };
+  token: { unitId: IUnitId; counter: bigint; value: bigint; typeId: IUnitId };
   targetToken: { unitId: IUnitId; counter: bigint };
 }
 
@@ -29,7 +28,7 @@ export class BurnFungibleToken {
         data.token.unitId,
         TokenPartitionTransactionType.BurnFungibleToken,
         new BurnFungibleTokenAttributes(
-          data.type.unitId,
+          data.token.typeId,
           data.token.value,
           data.targetToken.unitId,
           data.targetToken.counter,

--- a/src/tokens/transactions/CreateFungibleToken.ts
+++ b/src/tokens/transactions/CreateFungibleToken.ts
@@ -16,7 +16,7 @@ import { TokenUnitId } from '../TokenUnitId.js';
 export type CreateFungibleTokenTransactionOrder = TransactionOrder<CreateFungibleTokenAttributes, OwnerProofAuthProof>;
 interface ICreateFungibleTokenTransactionData extends ITransactionData {
   ownerPredicate: IPredicate;
-  type: { unitId: IUnitId };
+  typeId: IUnitId;
   value: bigint;
   nonce: bigint;
 }
@@ -25,7 +25,7 @@ export class CreateFungibleToken {
   public static create(
     data: ICreateFungibleTokenTransactionData,
   ): OwnerProofUnsignedTransactionOrder<CreateFungibleTokenAttributes> {
-    const attributes = new CreateFungibleTokenAttributes(data.type.unitId, data.value, data.ownerPredicate, data.nonce);
+    const attributes = new CreateFungibleTokenAttributes(data.typeId, data.value, data.ownerPredicate, data.nonce);
     const metadata = ClientMetadata.create(data.metadata);
     const tokenUnitId = TokenUnitId.create(attributes, metadata, TokenPartitionUnitType.FUNGIBLE_TOKEN);
     return new OwnerProofUnsignedTransactionOrder(

--- a/src/tokens/transactions/SplitFungibleToken.ts
+++ b/src/tokens/transactions/SplitFungibleToken.ts
@@ -16,10 +16,9 @@ export type SplitFungibleTokenTransactionOrder = TransactionOrder<
   TypeOwnerProofsAuthProof
 >;
 interface ISplitFungibleTokenTransactionData extends ITransactionData {
-  token: { unitId: IUnitId; counter: bigint };
+  token: { unitId: IUnitId; counter: bigint; typeId: IUnitId };
   ownerPredicate: IPredicate;
   amount: bigint;
-  type: { unitId: IUnitId };
 }
 
 export class SplitFungibleToken {
@@ -33,7 +32,7 @@ export class SplitFungibleToken {
         PartitionIdentifier.TOKEN,
         data.token.unitId,
         TokenPartitionTransactionType.SplitFungibleToken,
-        new SplitFungibleTokenAttributes(data.type.unitId, data.amount, data.ownerPredicate, data.token.counter),
+        new SplitFungibleTokenAttributes(data.token.typeId, data.amount, data.ownerPredicate, data.token.counter),
         data.stateLock,
         ClientMetadata.create(data.metadata),
       ),

--- a/src/tokens/transactions/TransferFungibleToken.ts
+++ b/src/tokens/transactions/TransferFungibleToken.ts
@@ -16,9 +16,8 @@ export type TransferFungibleTokenTransactionOrder = TransactionOrder<
   TypeOwnerProofsAuthProof
 >;
 interface ITransferFungibleTokenTransactionData extends ITransactionData {
-  token: { unitId: IUnitId; counter: bigint; value: bigint };
+  token: { unitId: IUnitId; counter: bigint; value: bigint; typeId: IUnitId };
   ownerPredicate: IPredicate;
-  type: { unitId: IUnitId };
 }
 
 export class TransferFungibleToken {
@@ -33,7 +32,7 @@ export class TransferFungibleToken {
         data.token.unitId,
         TokenPartitionTransactionType.TransferFungibleToken,
         new TransferFungibleTokenAttributes(
-          data.type.unitId,
+          data.token.typeId,
           data.token.value,
           data.ownerPredicate,
           data.token.counter,

--- a/src/tokens/transactions/TransferNonFungibleToken.ts
+++ b/src/tokens/transactions/TransferNonFungibleToken.ts
@@ -16,9 +16,8 @@ export type TransferNonFungibleTokenTransactionOrder = TransactionOrder<
   TypeOwnerProofsAuthProof
 >;
 interface ITransferNonFungibleTokenTransactionData extends ITransactionData {
-  token: { unitId: IUnitId; counter: bigint };
+  token: { unitId: IUnitId; counter: bigint; typeId: IUnitId };
   ownerPredicate: IPredicate;
-  type: { unitId: IUnitId };
 }
 
 export class TransferNonFungibleToken {
@@ -32,7 +31,7 @@ export class TransferNonFungibleToken {
         PartitionIdentifier.TOKEN,
         data.token.unitId,
         TokenPartitionTransactionType.TransferNonFungibleToken,
-        new TransferNonFungibleTokenAttributes(data.type.unitId, data.ownerPredicate, data.token.counter),
+        new TransferNonFungibleTokenAttributes(data.token.typeId, data.ownerPredicate, data.token.counter),
         data.stateLock,
         ClientMetadata.create(data.metadata),
       ),

--- a/tests/integration/tokens/TokenPartitionIntegrationTest.ts
+++ b/tests/integration/tokens/TokenPartitionIntegrationTest.ts
@@ -104,7 +104,7 @@ describe('Token Client Integration Tests', () => {
       console.log('Creating fungible token...');
       const createFungibleTokenTransactionOrder = await CreateFungibleToken.create({
         ownerPredicate: ownerPredicate,
-        type: { unitId: tokenTypeUnitId },
+        typeId: tokenTypeUnitId,
         value: 10n,
         nonce: 0n,
         ...createTransactionData(round, feeCreditRecordId),
@@ -135,7 +135,6 @@ describe('Token Client Integration Tests', () => {
         token: token!,
         ownerPredicate: ownerPredicate,
         amount: 3n,
-        type: { unitId: tokenTypeUnitId },
         ...createTransactionData(round, feeCreditRecordId),
       }).sign(proofFactory, proofFactory, [alwaysTrueProofFactory]);
 
@@ -148,7 +147,7 @@ describe('Token Client Integration Tests', () => {
       const splitTokenId = splitBillProof.transactionRecord.serverMetadata.targetUnitIds.find(
         (id: IUnitId) => !UnitId.equals(id, token!.unitId),
       );
-      expect(splitTokenId).not.toBeFalsy();
+      expect(splitTokenId).not.toBeNull();
 
       const splitToken = await tokenClient.getUnit(splitTokenId!, false, FungibleToken);
       const originalTokenAfterSplit = await tokenClient.getUnit(tokenUnitId, false, FungibleToken);
@@ -156,7 +155,6 @@ describe('Token Client Integration Tests', () => {
       console.log('Burning fungible token...');
       const burnFungibleTokenHash = await tokenClient.sendTransaction(
         await BurnFungibleToken.create({
-          type: { unitId: tokenTypeUnitId },
           token: splitToken!,
           targetToken: originalTokenAfterSplit!,
           ...createTransactionData(round, feeCreditRecordId),
@@ -190,7 +188,6 @@ describe('Token Client Integration Tests', () => {
       const transferFungibleTokenTransactionOrder = await TransferFungibleToken.create({
         token: token!,
         ownerPredicate: ownerPredicate,
-        type: { unitId: tokenTypeUnitId },
         ...createTransactionData(round, feeCreditRecordId),
       }).sign(proofFactory, proofFactory, [alwaysTrueProofFactory]);
 
@@ -330,7 +327,6 @@ describe('Token Client Integration Tests', () => {
       const transferNonFungibleTokenTransactionOrder = await TransferNonFungibleToken.create({
         token: token!,
         ownerPredicate: ownerPredicate,
-        type: { unitId: tokenTypeUnitId },
         ...createTransactionData(round, feeCreditRecordId),
       }).sign(proofFactory, proofFactory, [alwaysTrueProofFactory]);
 

--- a/tests/unit/transaction/attributes/SetFeeCreditAttributesTest.ts
+++ b/tests/unit/transaction/attributes/SetFeeCreditAttributesTest.ts
@@ -1,0 +1,22 @@
+import { SetFeeCreditAttributes } from '../../../../src/fees/attributes/SetFeeCreditAttributes.js';
+import { PredicateBytes } from '../../../../src/transaction/predicates/PredicateBytes.js';
+
+describe('Set Fee credit attributes', () => {
+  it('is returning correct data from decode with 0 as counter', () => {
+    const attributes = SetFeeCreditAttributes.fromCbor(
+      new SetFeeCreditAttributes(new PredicateBytes(new Uint8Array()), 0n, 0n).encode(),
+    );
+    expect(attributes.ownerPredicate.bytes).toStrictEqual(new Uint8Array());
+    expect(attributes.amount).toStrictEqual(0n);
+    expect(attributes.counter).toStrictEqual(0n);
+  });
+
+  it('is returning correct data from decode with null as counter', () => {
+    const attributes = SetFeeCreditAttributes.fromCbor(
+      new SetFeeCreditAttributes(new PredicateBytes(new Uint8Array()), 0n, null).encode(),
+    );
+    expect(attributes.ownerPredicate.bytes).toStrictEqual(new Uint8Array());
+    expect(attributes.amount).toStrictEqual(0n);
+    expect(attributes.counter).toBeNull();
+  });
+});

--- a/tests/unit/transaction/attributes/TransferFeeCreditAttributesTest.ts
+++ b/tests/unit/transaction/attributes/TransferFeeCreditAttributesTest.ts
@@ -1,0 +1,43 @@
+import { TransferFeeCreditAttributes } from '../../../../src/fees/attributes/TransferFeeCreditAttributes.js';
+import { PartitionIdentifier } from '../../../../src/PartitionIdentifier.js';
+import { UnitId } from '../../../../src/UnitId.js';
+
+describe('Transfer Fee credit attributes', () => {
+  it('is returning correct data from decode with 0 as counter', () => {
+    const attributes = TransferFeeCreditAttributes.fromCbor(
+      new TransferFeeCreditAttributes(
+        1n,
+        PartitionIdentifier.TOKEN,
+        UnitId.fromBytes(new Uint8Array(32)),
+        2n,
+        0n,
+        3n,
+      ).encode(),
+    );
+    expect(attributes.amount).toStrictEqual(1n);
+    expect(attributes.targetPartitionIdentifier).toStrictEqual(PartitionIdentifier.TOKEN);
+    expect(attributes.targetUnitId).toStrictEqual(UnitId.fromBytes(new Uint8Array(32)));
+    expect(attributes.latestAdditionTime).toStrictEqual(2n);
+    expect(attributes.targetUnitCounter).toStrictEqual(0n);
+    expect(attributes.counter).toStrictEqual(3n);
+  });
+
+  it('is returning correct data from decode with null as counter', () => {
+    const attributes = TransferFeeCreditAttributes.fromCbor(
+      new TransferFeeCreditAttributes(
+        1n,
+        PartitionIdentifier.TOKEN,
+        UnitId.fromBytes(new Uint8Array(32)),
+        2n,
+        null,
+        3n,
+      ).encode(),
+    );
+    expect(attributes.amount).toStrictEqual(1n);
+    expect(attributes.targetPartitionIdentifier).toStrictEqual(PartitionIdentifier.TOKEN);
+    expect(attributes.targetUnitId).toStrictEqual(UnitId.fromBytes(new Uint8Array(32)));
+    expect(attributes.latestAdditionTime).toStrictEqual(2n);
+    expect(attributes.targetUnitCounter).toBeNull();
+    expect(attributes.counter).toStrictEqual(3n);
+  });
+});


### PR DESCRIPTION
- Simplify passing token type ID to requests
- Fix `counter` tertiary `if` usage to properly use `bigint` in case of null